### PR TITLE
chore: weekly maintenance — dependency updates, security, SEO & lint

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,12 @@
+# Dependencies
+node_modules
+pnpm-lock.yaml
+
+# Build output & generated artifacts
+.next
+out
+build
+coverage
+next-env.d.ts
+build-info.json
+*.tsbuildinfo

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,3 @@
 {
-    "plugins": ["prettier-plugin-tailwindcss"]
-  }
+  "plugins": ["prettier-plugin-tailwindcss"]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,20 +9,24 @@ This is a Next.js 16 website for **Hundefreunde Herzogenrath e.V.**, a dog train
 ## Development Commands
 
 ### Essential Commands
+
 - `pnpm dev` - Start development server with Turbopack
 - `pnpm build` - Create production build (runs prebuild.js first)
 - `pnpm start` - Start production server
 - `pnpm lint` - Run ESLint
 
 ### Package Management
+
 This project uses **pnpm** as the package manager (version 10.20.0). Always use `pnpm` commands, not npm or yarn.
 
 ## Architecture Overview
 
 ### Content Management Strategy
+
 The site uses **Contentful** as a headless CMS with a GraphQL API. Content is fetched server-side using the Contentful GraphQL API (`data-provider/contentful/client/index.tsx`).
 
 **Environment Variables Required:**
+
 - `CONTENTFUL_SPACE_ID` - Contentful space identifier
 - `CONTENTFUL_ACCESS_TOKEN` - Delivery API token
 - `CONTENTFUL_PREVIEW_ACCESS_TOKEN` - Preview API token (optional)
@@ -32,12 +36,14 @@ The site uses **Contentful** as a headless CMS with a GraphQL API. Content is fe
 ### Directory Structure
 
 **`app/`** - Next.js App Router
+
 - `app/(content)/` - Route group for main content pages (shares layout with header/footer/jumbotron)
 - `app/layout.tsx` - Root layout with global styles
 - `app/(content)/layout.tsx` - Content layout with navigation, jumbotron, and footer
 - Static generation is preferred: many pages use `export const dynamic = "force-static"`
 
 **`components/`** - Reusable React components organized by feature:
+
 - `navigation/` - Header, Footer, Jumbotron components
 - `blog/` - Blog-related components
 - `gallery-card/` - Gallery display components
@@ -47,11 +53,13 @@ The site uses **Contentful** as a headless CMS with a GraphQL API. Content is fe
 **`sections/`** - Page sections used to compose pages (e.g., `motd/`, `kurse/`, `neuigkeiten/`, `bilder/`, `anfahrt/`, `faq/`)
 
 **`data-provider/contentful/`** - Contentful integration layer
+
 - `client/` - GraphQL fetch function
 - `provider/` - Data providers for different content types (blog posts, galleries, MOTD)
 - `types/` - TypeScript types for Contentful content models
 
 **`configuration/`** - Site configuration
+
 - `index.tsx` - Base site configuration (title, description, baseUrl, blogPostsPerPage)
 - `kursData.tsx` - Static course/training data
 
@@ -60,6 +68,7 @@ The site uses **Contentful** as a headless CMS with a GraphQL API. Content is fe
 ### Build Process
 
 **prebuild.js** - Runs before each build to generate `build-info.json` containing:
+
 - Version from package.json
 - Commit count from GitHub API
 - Build date
@@ -74,6 +83,7 @@ This build info is used by the build-number component.
 3. Components consume data and render using Contentful's rich text renderer (`@contentful/rich-text-react-renderer`)
 
 **Key Content Types:**
+
 - Blog Posts (TypeBlogPost)
 - Image Galleries (TypeImageGallery)
 - MOTD (Message of the Day)
@@ -82,6 +92,7 @@ This build info is used by the build-number component.
 ### Image Handling
 
 Next.js Image component is configured for Contentful CDN:
+
 - Remote patterns: `images.ctfassets.net`, `downloads.ctfassets.net`
 - Formats: WebP, AVIF
 - Cache TTL: 30 days (2592000 seconds)
@@ -98,6 +109,7 @@ Next.js Image component is configured for Contentful CDN:
 ### Route Groups
 
 The `(content)` route group shares a common layout with:
+
 - Header with navigation menu
 - Jumbotron with hero image
 - Footer with links
@@ -112,6 +124,7 @@ Most pages use static generation (`force-static` or default behavior). Contentfu
 ### SEO & Structured Data
 
 The site includes comprehensive SEO features:
+
 - Metadata generation per page
 - Structured data components for:
   - LocalBusiness
@@ -131,10 +144,13 @@ The site includes comprehensive SEO features:
 ## Development Guidelines
 
 ### TypeScript Paths
+
 Path aliases use `@/*` mapping to root directory (defined in `tsconfig.json`).
 
 ### Performance Optimizations
+
 Package imports are optimized in `next.config.mjs`:
+
 - @heroicons/react
 - @headlessui/react
 - @contentful/rich-text-react-renderer
@@ -142,11 +158,13 @@ Package imports are optimized in `next.config.mjs`:
 - embla-carousel-react
 
 ### Deployment
+
 The site is deployed on **Vercel** with automatic deployments from the main branch.
 
 ## Content Editing Workflow
 
 Content is managed in Contentful CMS. When content is updated:
+
 1. Changes are made in Contentful
 2. Webhook triggers Vercel rebuild (if configured), or
 3. Manual deployment/build fetches latest content

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Die offizielle Website der **Hundefreunde Herzogenrath e.V.** - ein moderner, re
 ### 🎯 Hauptfunktionen
 
 - 📝 **Content Management** - Dynamische Inhalte über Contentful CMS
-- 🖼️ **Bildergalerien** - Interaktive Galerie für Events und Aktivitäten  
+- 🖼️ **Bildergalerien** - Interaktive Galerie für Events und Aktivitäten
 - 📰 **Blog-System** - Aktuelle Nachrichten und Vereinsinformationen
 - 📅 **Kursmanagement** - Detaillierte Kursinformationen und Terminplanung
 - 👥 **Team-Profile** - Vorstellung der Trainer und Vereinsmitglieder
@@ -26,39 +26,46 @@ Die offizielle Website der **Hundefreunde Herzogenrath e.V.** - ein moderner, re
 ## 🚀 Tech Stack
 
 ### Frontend
+
 - **[Next.js 14](https://nextjs.org/)** - React Framework mit App Router
 - **[TypeScript](https://www.typescriptlang.org/)** - Typsichere Entwicklung
 - **[Tailwind CSS](https://tailwindcss.com/)** - Utility-First CSS Framework
 - **[React](https://reactjs.org/)** - UI Bibliothek
 
 ### Content Management
+
 - **[Contentful](https://www.contentful.com/)** - Headless CMS
 - **[Contentful Delivery API](https://www.contentful.com/developers/docs/references/content-delivery-api/)** - Content API
 
 ### Entwicklung & Build
+
 - **[PNPM](https://pnpm.io/)** - Package Manager
 - **[ESLint](https://eslint.org/)** - Code Linting
 - **[PostCSS](https://postcss.org/)** - CSS Processing
 
 ### Hosting & Deployment
+
 - **[Vercel](https://vercel.com/)** - Deployment Platform
 
 ## 🛠️ Installation & Entwicklung
 
 ### Voraussetzungen
-- Node.js 18+ 
+
+- Node.js 18+
 - PNPM (empfohlen) oder npm
 - Git
 
 ### Lokale Entwicklung starten
 
 1. **Repository klonen**
+
 ```bash
 git clone https://github.com/parns/next.hundefreunde-herzogenrath.de.git
 cd next.hundefreunde-herzogenrath.de
 ```
 
 2. **Abhängigkeiten installieren**
+
 ```bash
 pnpm install
 # oder
@@ -66,24 +73,26 @@ npm install
 ```
 
 3. **Umgebungsvariablen konfigurieren**
+
 ```bash
 # .env.local erstellen und Contentful API Keys hinzufügen
 cp .env.example .env.local
 ```
 
 4. **Entwicklungsserver starten**
+
 ```bash
 pnpm dev
 # oder
 npm run dev
-# oder  
+# oder
 yarn dev
 # oder
 bun dev
 ```
 
 5. **Website öffnen**  
-Öffne [http://localhost:3000](http://localhost:3000) in deinem Browser.
+   Öffne [http://localhost:3000](http://localhost:3000) in deinem Browser.
 
 ### 📝 Entwicklung
 
@@ -147,7 +156,7 @@ pnpm start
 ## 📖 Weiterführende Ressourcen
 
 - 📚 [Next.js Dokumentation](https://nextjs.org/docs) - Erfahre mehr über Next.js Features und API
-- 🎓 [Next.js Tutorial](https://nextjs.org/learn) - Interaktives Next.js Tutorial  
+- 🎓 [Next.js Tutorial](https://nextjs.org/learn) - Interaktives Next.js Tutorial
 - 🎨 [Tailwind CSS Docs](https://tailwindcss.com/docs) - Utility-First CSS Framework
 - 📝 [Contentful Docs](https://www.contentful.com/developers/docs/) - Headless CMS Dokumentation
 
@@ -176,10 +185,10 @@ Alle Rechte vorbehalten. Die Nutzung, Vervielfältigung oder Verbreitung ohne au
 ## 👨‍💻 Autor
 
 **Patrick Arns**  
-*Full-Stack Developer & Digital Solutions Architect*
+_Full-Stack Developer & Digital Solutions Architect_
 
 [![Website](https://img.shields.io/badge/Website-arns.dev-blue?style=for-the-badge&logo=safari)](https://arns.dev)
 [![GitHub](https://img.shields.io/badge/GitHub-PatrickArns-black?style=for-the-badge&logo=github)](https://github.com/PArns)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-Connect-0077B5?style=for-the-badge&logo=linkedin)](https://linkedin.com/in/patrick-arns)
 
-*Spezialisiert auf Rust & VPN Technik*
+_Spezialisiert auf Rust & VPN Technik_

--- a/app/(content)/aktuelles/artikel/[slug]/page.tsx
+++ b/app/(content)/aktuelles/artikel/[slug]/page.tsx
@@ -88,7 +88,7 @@ export default async function BlogArticle({
             <RichTextRenderer document={article.body} />
           </div>
         </article>
-        <div className="pb-2 pt-6">
+        <div className="pt-6 pb-2">
           <Button href="/aktuelles">Zurück zur Übersicht</Button>
         </div>
       </ContentBox>

--- a/app/(content)/aktuelles/seite/[pageNr]/page.tsx
+++ b/app/(content)/aktuelles/seite/[pageNr]/page.tsx
@@ -30,9 +30,9 @@ export async function generateStaticParams(): Promise<PostPageParams[]> {
 
   if (!posts) notFound();
 
-  const pageCount = posts.length / postsPerPage;
+  const pageCount = Math.ceil(posts.length / postsPerPage);
 
-  for (let x: number = 1; x < pageCount; x++) {
+  for (let x: number = 1; x <= pageCount; x++) {
     entries.push({ pageNr: x.toString() });
   }
 

--- a/app/(content)/aktuelles/seite/[pageNr]/page.tsx
+++ b/app/(content)/aktuelles/seite/[pageNr]/page.tsx
@@ -32,7 +32,7 @@ export async function generateStaticParams(): Promise<PostPageParams[]> {
 
   const pageCount = posts.length / postsPerPage;
 
-  for (var x: number = 1; x < pageCount; x++) {
+  for (let x: number = 1; x < pageCount; x++) {
     entries.push({ pageNr: x.toString() });
   }
 
@@ -48,10 +48,7 @@ export default async function Aktuelles({
   const postsPerPage = PageBaseConfiguration().blogPostsPerPage;
   const activePage = +pageNr - 1;
 
-  const posts = await GetBlogPosts(
-    activePage * postsPerPage,
-    postsPerPage,
-  );
+  const posts = await GetBlogPosts(activePage * postsPerPage, postsPerPage);
 
   if (!posts) notFound();
 

--- a/app/(content)/anfahrt/page.tsx
+++ b/app/(content)/anfahrt/page.tsx
@@ -62,8 +62,8 @@ export default function Anfart() {
             oder samstags direkt auf dem Platz!
           </p>
           <p>
-            Beachtet bitte, das das <b>Training ausschließlich samstags</b>{" "}
-            statt findet. Eine detailierte Terminübersicht findet ihr aber auch
+            Beachtet bitte, dass das <b>Training ausschließlich samstags</b>{" "}
+            stattfindet. Eine detaillierte Terminübersicht findet ihr aber auch
             noch einmal{" "}
             <Link href="/termine" className="text-sky-600">
               HIER

--- a/app/(content)/anfahrt/page.tsx
+++ b/app/(content)/anfahrt/page.tsx
@@ -9,18 +9,20 @@ export const dynamic = "force-static";
 export function generateMetadata() {
   return {
     title: "Anfahrt & Kontakt",
-    description: "Besucht uns in Herzogenrath! Grenzstr. 9, 52134 Herzogenrath - direkt an der niederländischen Grenze. Kostenlose Probestunden samstags. Eigene Parkplätze und Sanitäranlagen vorhanden.",
+    description:
+      "Besucht uns in Herzogenrath! Grenzstr. 9, 52134 Herzogenrath - direkt an der niederländischen Grenze. Kostenlose Probestunden samstags. Eigene Parkplätze und Sanitäranlagen vorhanden.",
     keywords: [
       "Hundefreunde Herzogenrath Anfahrt",
-      "Grenzstraße 9 Herzogenrath", 
+      "Grenzstraße 9 Herzogenrath",
       "Probestunde Hundeschule",
       "Kontakt Hundetrainer",
       "Hundeschule Aachen Umgebung",
-      "Training samstags"
+      "Training samstags",
     ],
     openGraph: {
       title: "Anfahrt & Kontakt - Hundefreunde Herzogenrath",
-      description: "Besucht uns für eine kostenlose Probestunde in Herzogenrath, Grenzstr. 9",
+      description:
+        "Besucht uns für eine kostenlose Probestunde in Herzogenrath, Grenzstr. 9",
       type: "website",
     },
   };
@@ -30,13 +32,13 @@ export default function Anfart() {
   return (
     <>
       <Motds />
-      
+
       <ContentBox>
         <header>
           <h1>Anfahrt & Kontakt</h1>
           <h2>
-            Ihr findet das Trainingsgelände direkt an der niederländischen Grenze
-            in Herzogenrath
+            Ihr findet das Trainingsgelände direkt an der niederländischen
+            Grenze in Herzogenrath
           </h2>
         </header>
         <section>
@@ -60,9 +62,9 @@ export default function Anfart() {
             oder samstags direkt auf dem Platz!
           </p>
           <p>
-            Beachtet bitte, das das <b>Training ausschließlich samstags</b> statt
-            findet. Eine detailierte Terminübersicht findet ihr aber auch noch
-            einmal{" "}
+            Beachtet bitte, das das <b>Training ausschließlich samstags</b>{" "}
+            statt findet. Eine detailierte Terminübersicht findet ihr aber auch
+            noch einmal{" "}
             <Link href="/termine" className="text-sky-600">
               HIER
             </Link>

--- a/app/(content)/bilder/page.tsx
+++ b/app/(content)/bilder/page.tsx
@@ -20,11 +20,12 @@ export function generateMetadata() {
       "Welpentraining Fotos",
       "Hundeschule Galerie",
       "Training Impressionen",
-      "Herzogenrath Hundeverein Bilder"
+      "Herzogenrath Hundeverein Bilder",
     ],
     openGraph: {
       title: "Training & Veranstaltungen - Hundefreunde Herzogenrath",
-      description: "Bilder von unserem Hundetraining und Events in Herzogenrath",
+      description:
+        "Bilder von unserem Hundetraining und Events in Herzogenrath",
       type: "website",
     },
   };

--- a/app/(content)/impressum/page.tsx
+++ b/app/(content)/impressum/page.tsx
@@ -47,12 +47,22 @@ export default function Impressum() {
       <h3 className="pt-4">Bildmaterial:</h3>
       <p>
         Patrick Arns –{" "}
-        <a href="https://arns.dev" target="_blank" className="text-sky-600">
+        <a
+          href="https://arns.dev"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sky-600"
+        >
           https://arns.dev
         </a>
         <br />
         Unsplash.com – &nbsp;
-        <a href="https://unsplash.com" target="_blank" className="text-sky-600">
+        <a
+          href="https://unsplash.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sky-600"
+        >
           https://unsplash.com
         </a>
       </p>

--- a/app/(content)/impressum/page.tsx
+++ b/app/(content)/impressum/page.tsx
@@ -47,20 +47,12 @@ export default function Impressum() {
       <h3 className="pt-4">Bildmaterial:</h3>
       <p>
         Patrick Arns –{" "}
-        <a
-          href="https://arns.dev"
-          target="_blank"
-          className="text-sky-600"
-        >
+        <a href="https://arns.dev" target="_blank" className="text-sky-600">
           https://arns.dev
         </a>
         <br />
         Unsplash.com – &nbsp;
-        <a
-          href="https://unsplash.com"
-          target="_blank"
-          className="text-sky-600"
-        >
+        <a href="https://unsplash.com" target="_blank" className="text-sky-600">
           https://unsplash.com
         </a>
       </p>

--- a/app/(content)/kurse/page.tsx
+++ b/app/(content)/kurse/page.tsx
@@ -2,8 +2,8 @@ import ContentBox from "@/components/layout/default-box";
 import Link from "next/link";
 import Kurs from "@/components/kurs";
 import Calendar from "@/components/calendar";
-import Script from 'next/script';
-import PageBaseConfiguration from '@/configuration';
+import Script from "next/script";
+import PageBaseConfiguration from "@/configuration";
 
 import { kursData } from "@/configuration/kursData";
 import Motds from "@/sections/motd";
@@ -22,11 +22,12 @@ export function generateMetadata() {
       "Hundeschule Termine",
       "Anfängerkurs Hunde",
       "Leistungsprüfung Hunde",
-      "Hundefreunde Herzogenrath Kurse"
+      "Hundefreunde Herzogenrath Kurse",
     ],
     openGraph: {
       title: "Hundetraining Kurse - Hundefreunde Herzogenrath",
-      description: "Welpen, Anfänger, BGVP und Leistungskurse - Professionelles Hundetraining samstags in Herzogenrath.",
+      description:
+        "Welpen, Anfänger, BGVP und Leistungskurse - Professionelles Hundetraining samstags in Herzogenrath.",
       type: "website",
     },
   };
@@ -41,26 +42,26 @@ export default function Kurse() {
     "@context": "https://schema.org",
     "@graph": kursData.map((kurs) => ({
       "@type": "Course",
-      "name": kurs.name,
-      "description": `Kurs ${kurs.name} bei den Hundefreunden Herzogenrath e.V.`,
-      "provider": {
+      name: kurs.name,
+      description: `Kurs ${kurs.name} bei den Hundefreunden Herzogenrath e.V.`,
+      provider: {
         "@type": "Organization",
-        "name": "Hundefreunde Herzogenrath e.V.",
-        "sameAs": origin
+        name: "Hundefreunde Herzogenrath e.V.",
+        sameAs: origin,
       },
-      "offers": {
+      offers: {
         "@type": "Offer",
-        "url": `${origin}/kurse`,
-        "availability": "https://schema.org/InStock"
+        url: `${origin}/kurse`,
+        availability: "https://schema.org/InStock",
       },
-      "hasCourseInstance": [
+      hasCourseInstance: [
         {
           "@type": "CourseInstance",
-          "courseMode": "https://schema.org/OfflineCourse",
-          "startDate": new Date().toISOString()
-        }
-      ]
-    }))
+          courseMode: "https://schema.org/OfflineCourse",
+          startDate: new Date().toISOString(),
+        },
+      ],
+    })),
   };
 
   return (
@@ -74,14 +75,17 @@ export default function Kurse() {
       <ContentBox>
         <header>
           <h1>Kurse, Termine & Zeiten</h1>
-          <p className="text-lg text-gray-600 mt-2">
-            Professionelles Hundetraining für alle Altersgruppen - von Welpen bis zur Leistungsklasse
+          <p className="mt-2 text-lg text-gray-600">
+            Professionelles Hundetraining für alle Altersgruppen - von Welpen
+            bis zur Leistungsklasse
           </p>
         </header>
-        
+
         <section aria-labelledby="kurs-info">
-          <h2 id="kurs-info" className="sr-only">Allgemeine Kursinformationen</h2>
-          
+          <h2 id="kurs-info" className="sr-only">
+            Allgemeine Kursinformationen
+          </h2>
+
           <div className="space-y-4">
             <p>
               Unsere Kurse finden wöchentlich jeweils{" "}
@@ -93,73 +97,98 @@ export default function Kurse() {
             </p>
 
             <p>
-              Solltest Du an einem <strong>Probetraining</strong> interessiert sein, so erscheine
-              bitte mindestens <strong>15 Minuten</strong> vor Kursbeginn und melde dich
-              einfach bei einem der Kursleiter an. Ein Probetraining ist
-              selbstverständlich <strong>kostenlos und unverbindlich</strong>!
+              Solltest Du an einem <strong>Probetraining</strong> interessiert
+              sein, so erscheine bitte mindestens <strong>15 Minuten</strong>{" "}
+              vor Kursbeginn und melde dich einfach bei einem der Kursleiter an.
+              Ein Probetraining ist selbstverständlich{" "}
+              <strong>kostenlos und unverbindlich</strong>!
             </p>
 
-            <div className="bg-blue-50 p-4 rounded-lg border-l-4 border-sky-400">
-              <h3 className="font-semibold text-sky-900 mb-2">Wichtige Kursinformationen</h3>
+            <div className="rounded-lg border-l-4 border-sky-400 bg-blue-50 p-4">
+              <h3 className="mb-2 font-semibold text-sky-900">
+                Wichtige Kursinformationen
+              </h3>
               <ul className="space-y-2 text-sky-800">
-                <li>• <strong>Kursdauer:</strong> 6 Monate (Start jeweils im April & Oktober)</li>
-                <li>• <strong>Übungsstunden:</strong> 60 Minuten inkl. Aufwärmen & freies Spiel</li>
-                <li>• <strong>Einstieg:</strong> Welpen & Anfänger jederzeit möglich</li>
-                <li>• <strong>Anwesenheit:</strong> Mindestens 50% für Prüfungszulassung</li>
+                <li>
+                  • <strong>Kursdauer:</strong> 6 Monate (Start jeweils im April
+                  & Oktober)
+                </li>
+                <li>
+                  • <strong>Übungsstunden:</strong> 60 Minuten inkl. Aufwärmen &
+                  freies Spiel
+                </li>
+                <li>
+                  • <strong>Einstieg:</strong> Welpen & Anfänger jederzeit
+                  möglich
+                </li>
+                <li>
+                  • <strong>Anwesenheit:</strong> Mindestens 50% für
+                  Prüfungszulassung
+                </li>
               </ul>
             </div>
           </div>
 
           <div className="mt-6">
-            <h3 className="font-semibold text-lg mb-3">Weitere wichtige Hinweise zum Training</h3>
+            <h3 className="mb-3 text-lg font-semibold">
+              Weitere wichtige Hinweise zum Training
+            </h3>
             <div className="space-y-3">
               <p>
                 Wir bitten um Verständnis, dass wir{" "}
-                <strong>5 Minuten nach Kursbeginn</strong> leider keine Nachzügler mehr auf die
-                Wiese lassen können - seid also am besten bereits 10 Minuten vor
-                Trainingsbeginn am Gelände.
+                <strong>5 Minuten nach Kursbeginn</strong> leider keine
+                Nachzügler mehr auf die Wiese lassen können - seid also am
+                besten bereits 10 Minuten vor Trainingsbeginn am Gelände.
               </p>
               <p>
-                Rund um unser Trainingsgelände gibt es zudem genügend Möglichkeiten
-                für kurze oder lange Spaziergänge. Bitte nutzt diese Möglichkeit auch{" "}
-                <strong>vor dem Training</strong> und plant genügend Zeit ein.
+                Rund um unser Trainingsgelände gibt es zudem genügend
+                Möglichkeiten für kurze oder lange Spaziergänge. Bitte nutzt
+                diese Möglichkeit auch <strong>vor dem Training</strong> und
+                plant genügend Zeit ein.
               </p>
               <p>
-                Ebenso sind wir als Teilnehmer und Hundeführer natürlich vorbildlich
-                und räumen die Hinterlassenschaften unserer Hunde sowohl draußen, als
-                auch auf dem Trainingsgelände weg.
+                Ebenso sind wir als Teilnehmer und Hundeführer natürlich
+                vorbildlich und räumen die Hinterlassenschaften unserer Hunde
+                sowohl draußen, als auch auf dem Trainingsgelände weg.
               </p>
             </div>
           </div>
         </section>
 
         <section aria-labelledby="kursabschluss">
-          <h2 id="kursabschluss" className="pt-6 text-xl font-semibold">Kursabschluss & Prüfungen</h2>
-          <div className="space-y-3 mt-3">
+          <h2 id="kursabschluss" className="pt-6 text-xl font-semibold">
+            Kursabschluss & Prüfungen
+          </h2>
+          <div className="mt-3 space-y-3">
             <p>
-              Jeder unserer Kurse endet mit einer <strong>Leistungsabfrage</strong> bzw., ab der
-              BGVP, mit einer <strong>offiziellen Prüfung</strong>, in der das Gelernte komprimiert in
-              praktischen Aufgaben abgefragt wird.
+              Jeder unserer Kurse endet mit einer{" "}
+              <strong>Leistungsabfrage</strong> bzw., ab der BGVP, mit einer{" "}
+              <strong>offiziellen Prüfung</strong>, in der das Gelernte
+              komprimiert in praktischen Aufgaben abgefragt wird.
             </p>
             <p>
-              Die <strong>BGVP-Prüfung</strong> besteht zusätzlich zur Praxis aus einer 
-              schriftlichen Prüfung und einer Prüfung in der Stadt.
+              Die <strong>BGVP-Prüfung</strong> besteht zusätzlich zur Praxis
+              aus einer schriftlichen Prüfung und einer Prüfung in der Stadt.
             </p>
           </div>
         </section>
 
         <section aria-labelledby="termine" className="mt-8">
-          <h2 id="termine" className="text-xl font-semibold mb-4">Aktuelle Termine</h2>
+          <h2 id="termine" className="mb-4 text-xl font-semibold">
+            Aktuelle Termine
+          </h2>
           <Calendar
             calendarId={process.env.NEXT_PUBLIC_GOOGLE_CALENDAR_ID}
             googleApiKey={process.env.NEXT_PUBLIC_GOOGLE_API_KEY}
-            className="border rounded-lg p-4 bg-gray-50"
+            className="rounded-lg border bg-gray-50 p-4"
           />
         </section>
       </ContentBox>
 
       <section aria-labelledby="kurs-angebot">
-        <h2 id="kurs-angebot" className="sr-only">Unser Kursangebot</h2>
+        <h2 id="kurs-angebot" className="sr-only">
+          Unser Kursangebot
+        </h2>
         {kursData.map((kurs, index) => (
           <Kurs
             key={kurs.id}

--- a/app/(content)/layout.tsx
+++ b/app/(content)/layout.tsx
@@ -33,7 +33,7 @@ export default function RootLayout({
                 aria-hidden="true"
               >
                 <div className="text-2xl md:text-4xl lg:text-6xl">
-                  Willkommmen
+                  Willkommen
                 </div>
                 <div className="text-xl md:text-2xl lg:text-4xl">
                   bei den Hundefreunden Herzogenrath e.V.

--- a/app/(content)/layout.tsx
+++ b/app/(content)/layout.tsx
@@ -27,7 +27,11 @@ export default function RootLayout({
               imageAlt="Willkommen bei den Hundefreunden Herzogenrath e.V."
               priority={true}
             >
-              <div className="text-center font-bold text-white drop-shadow-[0_1.2px_1.2px_rgba(0,0,0,0.8)]" role="banner" aria-hidden="true">
+              <div
+                className="text-center font-bold text-white drop-shadow-[0_1.2px_1.2px_rgba(0,0,0,0.8)]"
+                role="banner"
+                aria-hidden="true"
+              >
                 <div className="text-2xl md:text-4xl lg:text-6xl">
                   Willkommmen
                 </div>
@@ -41,16 +45,27 @@ export default function RootLayout({
       </Header>
 
       <div id="top"></div>
-      <main className="mx-auto max-w-(--breakpoint-2xl) px-6 2xl:px-0">{children}</main>
+      <main className="mx-auto max-w-(--breakpoint-2xl) px-6 2xl:px-0">
+        {children}
+      </main>
       <Footer>
-        <nav aria-label="Footer Navigation" className="flex flex-wrap gap-4 text-sm">
-          <Link href="/anfahrt" className="hover:text-white transition-colors">
+        <nav
+          aria-label="Footer Navigation"
+          className="flex flex-wrap gap-4 text-sm"
+        >
+          <Link href="/anfahrt" className="transition-colors hover:text-white">
             Anfahrt & Kontakt
           </Link>
-          <Link href="/impressum" className="hover:text-white transition-colors">
+          <Link
+            href="/impressum"
+            className="transition-colors hover:text-white"
+          >
             Impressum
           </Link>
-          <Link href="/aktuelles" className="hover:text-white transition-colors">
+          <Link
+            href="/aktuelles"
+            className="transition-colors hover:text-white"
+          >
             News
           </Link>
         </nav>

--- a/app/(content)/page.tsx
+++ b/app/(content)/page.tsx
@@ -5,7 +5,7 @@ import Kurse from "@/sections/kurse";
 import Motds from "@/sections/motd";
 import News from "@/sections/neuigkeiten";
 import FAQ from "@/sections/faq";
-import { YouTubeEmbed } from '@next/third-parties/google';
+import { YouTubeEmbed } from "@next/third-parties/google";
 import { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
@@ -28,16 +28,21 @@ export function generateMetadata(): Readonly<Metadata> {
       "Städteregion Aachen",
     ],
     openGraph: {
-      title: "Hundefreunde Herzogenrath e.V. - Die Hundeschule in der Städteregion Aachen",
-      description: "Seit 1996 bieten wir professionelle Hundeausbildung mit erfahrenen Trainern. Besucht uns für eine kostenlose Probestunde!",
+      title:
+        "Hundefreunde Herzogenrath e.V. - Die Hundeschule in der Städteregion Aachen",
+      description:
+        "Seit 1996 bieten wir professionelle Hundeausbildung mit erfahrenen Trainern. Besucht uns für eine kostenlose Probestunde!",
       type: "website",
+    },
+    alternates: {
+      canonical: "/",
     },
   };
 }
 
 export default function Home() {
   return (
-    <>      
+    <>
       <Motds />
 
       <ContentBox>
@@ -45,7 +50,7 @@ export default function Home() {
           <h1>Willkommen bei den Hundefreunden Herzogenrath e.V.</h1>
           <h2>Die Hundeschule in der StädteRegion Aachen</h2>
         </header>
-        
+
         <section>
           <p>
             Herzlich willkommen auf der offiziellen Webseite der Hundefreunde
@@ -82,8 +87,8 @@ export default function Home() {
                 wir arbeiten zusammen mit Euch auf das Semesterende hin!
               </p>
               <p>
-                Beachtet bitte, aufgrund dessen, dass wir ein Verein sind und alle
-                unsere{" "}
+                Beachtet bitte, aufgrund dessen, dass wir ein Verein sind und
+                alle unsere{" "}
                 <Link href="/team" className="text-sky-700">
                   Trainer und Helfer
                 </Link>{" "}
@@ -97,7 +102,7 @@ export default function Home() {
                 </Link>
               </p>
             </article>
-            <aside className="flex justify-start items-start pt-2 md:pt-12 md:ml-4">
+            <aside className="flex items-start justify-start pt-2 md:ml-4 md:pt-12">
               <Image
                 src={"/team/trainer.jpg"}
                 className="rounded-xl drop-shadow-lg"
@@ -108,10 +113,10 @@ export default function Home() {
               />
             </aside>
           </div>
-          <div className="flex justify-center items-center pt-4">
+          <div className="flex items-center justify-center pt-4">
             <div className="w-full max-w-2xl">
-              <YouTubeEmbed 
-                videoid="aaQPQfe_b2E" 
+              <YouTubeEmbed
+                videoid="aaQPQfe_b2E"
                 height={400}
                 params="controls=1&start=0&end=0&loop=0&playsinline=0&rel=0&enablejsapi=1"
               />

--- a/app/(content)/team/page.tsx
+++ b/app/(content)/team/page.tsx
@@ -69,7 +69,7 @@ const andrea: Member = {
     <>
       Seit 2022 bin ich mit meinem Welpen Louie zu den Hundefreunden gekommen
       und habe Feuer gefangen! Nachdem ich mit meinem Hund erfolgreich die BGVP
-      bestanden habe, wollte ich auch einmal die andere Seite der Medaillie
+      bestanden habe, wollte ich auch einmal die andere Seite der Medaille
       kennen lernen und bin seit Mai 2025 nun ebenfalls Trainerin. Solltet ihr
       nach einer unserer Stunden ebenfalls Lust und Laune verspüren, so macht
       mir dies doch gerne &quot;nach&quot;.

--- a/app/(content)/team/page.tsx
+++ b/app/(content)/team/page.tsx
@@ -17,11 +17,12 @@ export function generateMetadata() {
       "Erfahrene Hundetrainer Aachen",
       "Kontakt Hundetrainer",
       "Welpenkurs Trainer",
-      "BGVP Trainer"
+      "BGVP Trainer",
     ],
     openGraph: {
       title: "Unser Trainerteam - Hundefreunde Herzogenrath",
-      description: "Erfahrene und ehrenamtliche Hundetrainer mit jahrelanger Expertise in der Hundeerziehung.",
+      description:
+        "Erfahrene und ehrenamtliche Hundetrainer mit jahrelanger Expertise in der Hundeerziehung.",
       type: "website",
     },
   };
@@ -69,9 +70,9 @@ const andrea: Member = {
       Seit 2022 bin ich mit meinem Welpen Louie zu den Hundefreunden gekommen
       und habe Feuer gefangen! Nachdem ich mit meinem Hund erfolgreich die BGVP
       bestanden habe, wollte ich auch einmal die andere Seite der Medaillie
-      kennen lernen und bin seit Mai 2025 nun ebenfalls Trainerin. Solltet ihr nach einer
-      unserer Stunden ebenfalls Lust und Laune verspüren, so macht mir dies doch
-      gerne &quot;nach&quot;.
+      kennen lernen und bin seit Mai 2025 nun ebenfalls Trainerin. Solltet ihr
+      nach einer unserer Stunden ebenfalls Lust und Laune verspüren, so macht
+      mir dies doch gerne &quot;nach&quot;.
     </>
   ),
 };
@@ -237,12 +238,7 @@ const ralfConstruction: Member = {
 
 // -----------------------------------------------------------------------------------
 
-const trainer: Array<Member> = [
-  andrea,
-  marianne,
-  birgit,
-  patrick,
-];
+const trainer: Array<Member> = [andrea, marianne, birgit, patrick];
 
 const judges: Array<Member> = [marianneJudge, heinzJudge, udoJudge];
 
@@ -260,7 +256,7 @@ export default function Team() {
   return (
     <>
       <Motds />
-      
+
       <ContentBox>
         <header>
           <h1>Unser Team</h1>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,6 +1,6 @@
 @import "tailwindcss";
 
-@config '../tailwind.config.ts';
+@config "../tailwind.config.ts";
 
 /*
   The default border color has changed to `currentColor` in Tailwind CSS v4,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -40,11 +40,11 @@ export function generateMetadata(): Readonly<Metadata> {
       locale: "de-DE",
       siteName: "Hundefreunde Herzogenrath e.V.",
       type: "website",
-      images: { 
-        url: "/jumbotron/gruppe.jpg", 
-        width: 1200, 
+      images: {
+        url: "/jumbotron/gruppe.jpg",
+        width: 1200,
         height: 630,
-        alt: "Hundefreunde Herzogenrath - Hundetraining Gruppe"
+        alt: "Hundefreunde Herzogenrath - Hundetraining Gruppe",
       },
     },
     twitter: {
@@ -52,9 +52,6 @@ export function generateMetadata(): Readonly<Metadata> {
       title: config.title,
       description: config.description,
       images: ["/jumbotron/gruppe.jpg"],
-    },
-    alternates: {
-      canonical: config.baseUrl,
     },
   };
 }

--- a/app/robots.tsx
+++ b/app/robots.tsx
@@ -1,15 +1,15 @@
-import { MetadataRoute } from 'next'
-import PageBaseConfiguration from '@/configuration'
+import { MetadataRoute } from "next";
+import PageBaseConfiguration from "@/configuration";
 
 export default function robots(): MetadataRoute.Robots {
-  const config = PageBaseConfiguration()
-  const baseUrl = config.baseUrl.toString()
+  const config = PageBaseConfiguration();
+  const baseUrl = config.baseUrl.toString();
 
   return {
     rules: {
-      userAgent: '*',
-      allow: '/',
+      userAgent: "*",
+      allow: "/",
     },
     sitemap: `${baseUrl}sitemap.xml`,
-  }
+  };
 }

--- a/app/sitemap.tsx
+++ b/app/sitemap.tsx
@@ -1,109 +1,115 @@
-import { MetadataRoute } from 'next'
-import PageBaseConfiguration from '@/configuration'
-import { GetAllBlogPostSlugs } from '@/data-provider/contentful/provider/blog-post-provider'
-import { GetAllGallerySlugs } from '@/data-provider/contentful/provider/gallery-provider'
+import { MetadataRoute } from "next";
+import PageBaseConfiguration from "@/configuration";
+import { GetAllBlogPostSlugs } from "@/data-provider/contentful/provider/blog-post-provider";
+import { GetAllGallerySlugs } from "@/data-provider/contentful/provider/gallery-provider";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const config = PageBaseConfiguration()
-  const baseUrl = config.baseUrl.toString()
+  const config = PageBaseConfiguration();
+  const baseUrl = config.baseUrl.toString();
 
   // Statische Seiten
   const staticPages: MetadataRoute.Sitemap = [
     {
       url: baseUrl,
       lastModified: new Date(),
-      changeFrequency: 'weekly',
+      changeFrequency: "weekly",
       priority: 1,
     },
     {
       url: `${baseUrl}kurse`,
       lastModified: new Date(),
-      changeFrequency: 'monthly',
+      changeFrequency: "monthly",
       priority: 0.9,
     },
     {
       url: `${baseUrl}team`,
       lastModified: new Date(),
-      changeFrequency: 'monthly',
+      changeFrequency: "monthly",
       priority: 0.8,
     },
     {
       url: `${baseUrl}anfahrt`,
       lastModified: new Date(),
-      changeFrequency: 'monthly',
+      changeFrequency: "monthly",
       priority: 0.8,
     },
     {
       url: `${baseUrl}bilder`,
       lastModified: new Date(),
-      changeFrequency: 'weekly',
+      changeFrequency: "weekly",
       priority: 0.7,
     },
     {
       url: `${baseUrl}aktuelles`,
       lastModified: new Date(),
-      changeFrequency: 'daily',
+      changeFrequency: "daily",
       priority: 0.6,
     },
     {
       url: `${baseUrl}impressum`,
       lastModified: new Date(),
-      changeFrequency: 'yearly',
+      changeFrequency: "yearly",
       priority: 0.3,
     },
-  ]
+  ];
 
   // Dynamische Blog-Artikel mit tatsächlichen Publish-Daten
-  const blogPosts = await GetAllBlogPostSlugs() || []
-  const now = new Date()
-  const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000)
-  
+  const blogPosts = (await GetAllBlogPostSlugs()) || [];
+  const now = new Date();
+  const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+
   const blogPages: MetadataRoute.Sitemap = blogPosts.map((post) => {
     // Neue Posts haben höhere Priorität und häufigere Updates
-    const pubDate = new Date(post.publishedAt)
-    const isRecent = pubDate > thirtyDaysAgo
-    const lastModified = isNaN(pubDate.getTime()) ? now : pubDate
+    const pubDate = new Date(post.publishedAt);
+    const isRecent = pubDate > thirtyDaysAgo;
+    const lastModified = isNaN(pubDate.getTime()) ? now : pubDate;
 
     return {
       url: `${baseUrl}aktuelles/artikel/${post.slug}`,
       lastModified,
-      changeFrequency: isRecent ? 'weekly' as const : 'monthly' as const,
+      changeFrequency: isRecent ? ("weekly" as const) : ("monthly" as const),
       priority: isRecent ? 0.7 : 0.5,
-    }
-  })
+    };
+  });
 
   // Dynamische Bildergalerien mit Datum-basierter Priorität
-  const galleries = await GetAllGallerySlugs() || []
+  const galleries = (await GetAllGallerySlugs()) || [];
   const galleryPages: MetadataRoute.Sitemap = galleries.map((gallery) => {
-    const pubDate = new Date(gallery.publishedAt)
-    const isRecent = pubDate > thirtyDaysAgo
-    const lastModified = isNaN(pubDate.getTime()) ? now : pubDate
+    const pubDate = new Date(gallery.publishedAt);
+    const isRecent = pubDate > thirtyDaysAgo;
+    const lastModified = isNaN(pubDate.getTime()) ? now : pubDate;
 
     return {
       url: `${baseUrl}bilder/${gallery.slug}`,
       lastModified,
-      changeFrequency: 'monthly' as const,
+      changeFrequency: "monthly" as const,
       priority: isRecent ? 0.6 : 0.4,
-    }
-  })
+    };
+  });
 
   // Blog-Übersichtsseiten mit dynamischer Paginierung
-  const totalBlogPosts = blogPosts.length
-  const postsPerPage = 10
-  const totalPages = Math.ceil(totalBlogPosts / postsPerPage)
-  
+  const totalBlogPosts = blogPosts.length;
+  const postsPerPage = config.blogPostsPerPage;
+  const totalPages = Math.ceil(totalBlogPosts / postsPerPage);
+
   const blogPaginationPages: MetadataRoute.Sitemap = Array.from(
     { length: totalPages },
     (_, index) => {
-      const pageNumber = index + 1
+      const pageNumber = index + 1;
       return {
         url: `${baseUrl}aktuelles/seite/${pageNumber}`,
         lastModified: new Date(),
-        changeFrequency: 'daily' as const,
-        priority: pageNumber === 1 ? 0.6 : Math.max(0.3, 0.6 - (pageNumber * 0.1)),
-      }
-    }
-  )
+        changeFrequency: "daily" as const,
+        priority:
+          pageNumber === 1 ? 0.6 : Math.max(0.3, 0.6 - pageNumber * 0.1),
+      };
+    },
+  );
 
-  return [...staticPages, ...blogPages, ...galleryPages, ...blogPaginationPages]
+  return [
+    ...staticPages,
+    ...blogPages,
+    ...galleryPages,
+    ...blogPaginationPages,
+  ];
 }

--- a/components/article-structured-data/index.tsx
+++ b/components/article-structured-data/index.tsx
@@ -1,19 +1,19 @@
-import Script from 'next/script'
+import Script from "next/script";
 
 interface ArticleStructuredDataProps {
-  title: string
-  description: string
-  url: string
-  image?: string
-  publishedAt: Date
+  title: string;
+  description: string;
+  url: string;
+  image?: string;
+  publishedAt: Date;
   author?: {
-    name: string
-    url?: string
-  }
+    name: string;
+    url?: string;
+  };
   organization?: {
-    name: string
-    url: string
-  }
+    name: string;
+    url: string;
+  };
 }
 
 export default function ArticleStructuredData({
@@ -24,50 +24,50 @@ export default function ArticleStructuredData({
   publishedAt,
   author = {
     name: "Hundefreunde Herzogenrath e.V.",
-    url: "https://hundefreunde-herzogenrath.de/team"
+    url: "https://hundefreunde-herzogenrath.de/team",
   },
   organization = {
     name: "Hundefreunde Herzogenrath e.V.",
-    url: "https://hundefreunde-herzogenrath.de"
-  }
+    url: "https://hundefreunde-herzogenrath.de",
+  },
 }: ArticleStructuredDataProps) {
   const structuredData = {
     "@context": "https://schema.org",
     "@type": "Article",
-    "headline": title,
-    "description": description,
-    "url": url,
-    "datePublished": publishedAt.toISOString(),
-    "dateModified": publishedAt.toISOString(),
-    "author": {
+    headline: title,
+    description: description,
+    url: url,
+    datePublished: publishedAt.toISOString(),
+    dateModified: publishedAt.toISOString(),
+    author: {
       "@type": "Organization",
-      "name": author.name,
-      "url": author.url
+      name: author.name,
+      url: author.url,
     },
-    "publisher": {
+    publisher: {
       "@type": "Organization",
-      "name": organization.name,
-      "url": organization.url
+      name: organization.name,
+      url: organization.url,
     },
     ...(image && {
-      "image": {
+      image: {
         "@type": "ImageObject",
-        "url": image
-      }
+        url: image,
+      },
     }),
-    "mainEntityOfPage": {
+    mainEntityOfPage: {
       "@type": "WebPage",
-      "@id": url
-    }
-  }
+      "@id": url,
+    },
+  };
 
   return (
     <Script
       id="article-structured-data"
       type="application/ld+json"
       dangerouslySetInnerHTML={{
-        __html: JSON.stringify(structuredData, null, 2)
+        __html: JSON.stringify(structuredData, null, 2),
       }}
     />
-  )
+  );
 }

--- a/components/blog/blog-card/index.tsx
+++ b/components/blog/blog-card/index.tsx
@@ -5,49 +5,49 @@ import DateRenderer from "@/components/date-renderer";
 
 export default function BlogCard({ post }: { post: BlogPost }) {
   return (
-    <article className="flex flex-col w-full rounded-lg drop-shadow-lg h-full">
-        <Link href={`/aktuelles/artikel/${post.slug}`}>
-          <div className="relative overflow-hidden bg-cover bg-no-repeat p-36 lg:p-56">
-            <ContentfulImageAsset
-              asset={post.image}
-              alt={post.title}
-              fill={true}
-              quality={50}
-              className="absolute bottom-0 left-0 right-0 top-0 h-full w-full rounded-t-lg object-cover object-top"
-            />
+    <article className="flex h-full w-full flex-col rounded-lg drop-shadow-lg">
+      <Link href={`/aktuelles/artikel/${post.slug}`}>
+        <div className="relative overflow-hidden bg-cover bg-no-repeat p-36 lg:p-56">
+          <ContentfulImageAsset
+            asset={post.image}
+            alt={post.title}
+            fill={true}
+            quality={50}
+            className="absolute top-0 right-0 bottom-0 left-0 h-full w-full rounded-t-lg object-cover object-top"
+          />
 
-            <div className="absolute left-2 top-2 overflow-hidden">
-              <div className="text-white">
-                <h2 className="text-white drop-shadow-[0_1.2px_1.2px_rgba(0,0,0,0.8)]">
-                  {post.title}
-                </h2>
-                <h3 className="text-white drop-shadow-[0_1.2px_1.2px_rgba(0,0,0,0.8)]">
-                  {post.subTitle}
-                </h3>
-              </div>
-            </div>
-
-            <div className="absolute bottom-0 left-2 overflow-hidden">
-              <div className="text-lg font-semibold text-white drop-shadow-[0_1.2px_1.2px_rgba(0,0,0,0.8)]">
-                <DateRenderer date={post.publishedAt} format="long" />
-              </div>
+          <div className="absolute top-2 left-2 overflow-hidden">
+            <div className="text-white">
+              <h2 className="text-white drop-shadow-[0_1.2px_1.2px_rgba(0,0,0,0.8)]">
+                {post.title}
+              </h2>
+              <h3 className="text-white drop-shadow-[0_1.2px_1.2px_rgba(0,0,0,0.8)]">
+                {post.subTitle}
+              </h3>
             </div>
           </div>
-        </Link>
 
-        <div className="rounded-b-lg bg-white h-full p-2 flex flex-col">
-          <div className="h-full">
-            {post.excerpt && <div>{post.excerpt}</div>}
-          </div>
-          <div className="mr-1 mt-2 flex w-full flex-nowrap place-content-end text-neutral-800">
-            <Link
-              href={`/aktuelles/artikel/${post.slug}`}
-              className="rounded-sm bg-sky-400 px-2 py-2 font-semibold text-white transition hover:bg-sky-700 lg:px-4"
-            >
-              Mehr ...
-            </Link>
+          <div className="absolute bottom-0 left-2 overflow-hidden">
+            <div className="text-lg font-semibold text-white drop-shadow-[0_1.2px_1.2px_rgba(0,0,0,0.8)]">
+              <DateRenderer date={post.publishedAt} format="long" />
+            </div>
           </div>
         </div>
+      </Link>
+
+      <div className="flex h-full flex-col rounded-b-lg bg-white p-2">
+        <div className="h-full">
+          {post.excerpt && <div>{post.excerpt}</div>}
+        </div>
+        <div className="mt-2 mr-1 flex w-full flex-nowrap place-content-end text-neutral-800">
+          <Link
+            href={`/aktuelles/artikel/${post.slug}`}
+            className="rounded-sm bg-sky-400 px-2 py-2 font-semibold text-white transition hover:bg-sky-700 lg:px-4"
+          >
+            Mehr ...
+          </Link>
+        </div>
+      </div>
     </article>
   );
 }

--- a/components/blog/blog-header/index.tsx
+++ b/components/blog/blog-header/index.tsx
@@ -11,8 +11,8 @@ export default function BlogHeader({
   backgroundImage: any;
   useH1?: boolean;
 }) {
-  const TitleTag = useH1 ? 'h1' : 'div';
-  const SubTitleTag = useH1 ? 'h2' : 'div';
+  const TitleTag = useH1 ? "h1" : "div";
+  const SubTitleTag = useH1 ? "h2" : "div";
 
   return (
     <div className="relative w-full overflow-hidden rounded-lg bg-cover bg-no-repeat text-center">
@@ -24,7 +24,7 @@ export default function BlogHeader({
         priority={true}
         sizes="100vw"
         usePlaceholder={true}
-        className="absolute bottom-0 left-0 right-0 top-0 h-max w-max object-cover"
+        className="absolute top-0 right-0 bottom-0 left-0 h-max w-max object-cover"
       />
       <div className="py-16 md:py-28 lg:py-48 xl:py-64">
         <div className="flex h-full items-center justify-center">

--- a/components/blog/pagination/index.tsx
+++ b/components/blog/pagination/index.tsx
@@ -78,7 +78,7 @@ export default function Pagination({
 
   const pageLinks = [];
 
-  for (var i = 1; i <= pageCount; i++) {
+  for (let i = 1; i <= pageCount; i++) {
     pageLinks.push(
       <PageLink
         key={`page-${i}`}
@@ -98,7 +98,7 @@ export default function Pagination({
       >
         <Link
           href={previousLink}
-          className="aria-disabled:hover-none relative inline-flex items-center rounded-l-md bg-gray-50/60 px-2 py-2 text-neutral-400 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus:z-20 focus:outline-offset-0 aria-disabled:pointer-events-none"
+          className="aria-disabled:hover-none relative inline-flex items-center rounded-l-md bg-gray-50/60 px-2 py-2 text-neutral-400 ring-1 ring-gray-300 ring-inset hover:bg-gray-50 focus:z-20 focus:outline-offset-0 aria-disabled:pointer-events-none"
           aria-disabled={firstPage}
         >
           <span className="sr-only">Previous</span>
@@ -109,7 +109,7 @@ export default function Pagination({
 
         <Link
           href={nextLink}
-          className="aria-disabled:hover-none relative inline-flex items-center rounded-r-md bg-gray-50/60 px-2 py-2 text-neutral-400 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus:z-20 focus:outline-offset-0 aria-disabled:pointer-events-none"
+          className="aria-disabled:hover-none relative inline-flex items-center rounded-r-md bg-gray-50/60 px-2 py-2 text-neutral-400 ring-1 ring-gray-300 ring-inset hover:bg-gray-50 focus:z-20 focus:outline-offset-0 aria-disabled:pointer-events-none"
           aria-disabled={lastPage}
         >
           <span className="sr-only">Next</span>

--- a/components/build-number/index.tsx
+++ b/components/build-number/index.tsx
@@ -10,7 +10,8 @@ export default function BuildInfo() {
   return (
     <div className="flex items-center">
       <span className="text-xs">
-        Version: {buildInfo.buildNumber} ({buildDate.toLocaleDateString("de-DE")})
+        Version: {buildInfo.buildNumber} (
+        {buildDate.toLocaleDateString("de-DE")})
       </span>
     </div>
   );

--- a/components/contentful/image-asset/index.tsx
+++ b/components/contentful/image-asset/index.tsx
@@ -17,7 +17,13 @@ export interface ContentfulImageAssetProps {
   [key: string]: any; // For other props that might be passed
 }
 
-export function getImageSource(asset: any, width: number, height?: number, quality?: number, fit?: "pad" | "fill" | "scale" | "crop" | "thumb") {
+export function getImageSource(
+  asset: any,
+  width: number,
+  height?: number,
+  quality?: number,
+  fit?: "pad" | "fill" | "scale" | "crop" | "thumb",
+) {
   let assetSrc = asset?.url;
 
   if (!assetSrc) {
@@ -60,22 +66,22 @@ export default function ContentfulImageAsset(props: ContentfulImageAssetProps) {
   } = props;
 
   // Wenn width und height angegeben sind, verwende "fill" für exakte Dimensionen
-  const contentfulFit = (width && height) ? (fit || "fill") : "fill";
-  
+  const contentfulFit = width && height ? fit || "fill" : "fill";
+
   const imageSource = getImageSource(
-    asset, 
-    width ?? maxImageWidth ?? 1980, 
-    height ?? 1080, 
-    quality, 
-    contentfulFit
+    asset,
+    width ?? maxImageWidth ?? 1980,
+    height ?? 1080,
+    quality,
+    contentfulFit,
   );
-  
+
   if (!Boolean(imageSource) || imageSource === undefined) return <></>;
 
   // Wenn width und height angegeben sind, setze object-fit für korrekte Darstellung
   const imageStyle: CSSProperties = {
     ...style,
-    ...(width && height && !fill ? { objectFit: 'cover' } : {})
+    ...(width && height && !fill ? { objectFit: "cover" } : {}),
   };
 
   return (

--- a/components/contentful/rich-text-renderer/blogPostImage.tsx
+++ b/components/contentful/rich-text-renderer/blogPostImage.tsx
@@ -79,7 +79,7 @@ export default function BlogPostImage({ imageData }: { imageData: any }) {
               prev: undefined,
               src: "",
               width: 0,
-              height: 0
+              height: 0,
             });
           }
         }}

--- a/components/gallery-card/index.tsx
+++ b/components/gallery-card/index.tsx
@@ -12,8 +12,8 @@ export default function GalleryCard({ gallery }: { gallery: ImageGallery }) {
           height={600}
           alt={gallery.name}
           sizes="(max-width: 800px) 100vw, 800px, 400px, 200px"
-          className="rounded-t-lg object-cove relative h-full w-full"
-          style={{ objectPosition: 'center 40%' }}
+          className="object-cove relative h-full w-full rounded-t-lg"
+          style={{ objectPosition: "center 40%" }}
         />
 
         <div className="absolute bottom-0 left-2 overflow-hidden">

--- a/components/gallery-card/index.tsx
+++ b/components/gallery-card/index.tsx
@@ -12,7 +12,7 @@ export default function GalleryCard({ gallery }: { gallery: ImageGallery }) {
           height={600}
           alt={gallery.name}
           sizes="(max-width: 800px) 100vw, 800px, 400px, 200px"
-          className="object-cove relative h-full w-full rounded-t-lg"
+          className="relative h-full w-full rounded-t-lg object-cover"
           style={{ objectPosition: "center 40%" }}
         />
 

--- a/components/gallery-structured-data/index.tsx
+++ b/components/gallery-structured-data/index.tsx
@@ -1,21 +1,21 @@
-import Script from 'next/script'
+import Script from "next/script";
 
 interface GalleryStructuredDataProps {
-  name: string
-  description: string
-  url: string
+  name: string;
+  description: string;
+  url: string;
   images: Array<{
-    url: string
-    width?: number
-    height?: number
-    description?: string
-  }>
-  datePublished: Date
+    url: string;
+    width?: number;
+    height?: number;
+    description?: string;
+  }>;
+  datePublished: Date;
   organization?: {
-    name: string
-    url: string
-    logo: string
-  }
+    name: string;
+    url: string;
+    logo: string;
+  };
 }
 
 export default function GalleryStructuredData({
@@ -27,45 +27,45 @@ export default function GalleryStructuredData({
   organization = {
     name: "Hundefreunde Herzogenrath e.V.",
     url: "https://hundefreunde-herzogenrath.de",
-    logo: "https://hundefreunde-herzogenrath.de/theme/logo.png"
-  }
+    logo: "https://hundefreunde-herzogenrath.de/theme/logo.png",
+  },
 }: GalleryStructuredDataProps) {
   const structuredData = {
     "@context": "https://schema.org",
     "@type": "ImageGallery",
-    "name": name,
-    "description": description,
-    "url": url,
-    "datePublished": datePublished.toISOString(),
-    "publisher": {
+    name: name,
+    description: description,
+    url: url,
+    datePublished: datePublished.toISOString(),
+    publisher: {
       "@type": "Organization",
-      "name": organization.name,
-      "url": organization.url,
-      "logo": {
+      name: organization.name,
+      url: organization.url,
+      logo: {
         "@type": "ImageObject",
-        "url": organization.logo
-      }
+        url: organization.logo,
+      },
     },
-    "image": images.map(img => ({
+    image: images.map((img) => ({
       "@type": "ImageObject",
-      "url": img.url,
-      "description": img.description || name,
-      ...(img.width && { "width": img.width }),
-      ...(img.height && { "height": img.height })
+      url: img.url,
+      description: img.description || name,
+      ...(img.width && { width: img.width }),
+      ...(img.height && { height: img.height }),
     })),
-    "mainEntityOfPage": {
+    mainEntityOfPage: {
       "@type": "WebPage",
-      "@id": url
-    }
-  }
+      "@id": url,
+    },
+  };
 
   return (
     <Script
       id="gallery-structured-data"
       type="application/ld+json"
       dangerouslySetInnerHTML={{
-        __html: JSON.stringify(structuredData, null, 2)
+        __html: JSON.stringify(structuredData, null, 2),
       }}
     />
-  )
+  );
 }

--- a/components/kurs/index.tsx
+++ b/components/kurs/index.tsx
@@ -45,9 +45,11 @@ export default function Kurs({
     <ContentBox>
       <article itemScope itemType="https://schema.org/EducationalOrganization">
         <header>
-          <h2 id={id} itemProp="name">{name}</h2>
+          <h2 id={id} itemProp="name">
+            {name}
+          </h2>
         </header>
-        
+
         <div className="flex flex-col lg:flex-row">
           <div className="relative mx-auto min-h-[250px] w-full lg:order-last lg:ml-4 lg:w-[550px]">
             <Image
@@ -58,21 +60,25 @@ export default function Kurs({
               itemProp="image"
             />
           </div>
-          
+
           <div className="flex h-auto w-full flex-col">
-            <div className="pb-2 pt-2 lg:pt-0" itemProp="description">
+            <div className="pt-2 pb-2 lg:pt-0" itemProp="description">
               {children}
             </div>
 
             <div className="mt-auto flex flex-col space-y-2">
               <div itemScope itemType="https://schema.org/Person">
-                <strong className="pr-1">Kursleiter:</strong> 
+                <strong className="pr-1">Kursleiter:</strong>
                 <span itemProp="instructor">
                   <KursLeiter leiter={leiter} />
                 </span>
               </div>
-              
-              <div className="font-semibold text-gray-600" itemScope itemType="https://schema.org/Schedule">
+
+              <div
+                className="font-semibold text-gray-600"
+                itemScope
+                itemType="https://schema.org/Schedule"
+              >
                 <time itemProp="startTime" dateTime={`${startTime}:00`}>
                   Der {name} findet von {startTime} Uhr
                 </time>

--- a/components/kursbox/index.tsx
+++ b/components/kursbox/index.tsx
@@ -19,10 +19,10 @@ export default function KursBox({
   const endTime = addOneHour(startTime);
 
   return (
-    <article 
-      itemScope 
+    <article
+      itemScope
       itemType="https://schema.org/Course"
-      className="flex h-full flex-col rounded-lg border bg-white shadow-lg hover:shadow-xl transition-shadow"
+      className="flex h-full flex-col rounded-lg border bg-white shadow-lg transition-shadow hover:shadow-xl"
     >
       <Link
         href={`/kurse/#${name}`}
@@ -46,12 +46,16 @@ export default function KursBox({
         <header className="pt-2 text-center">
           <h3 itemProp="name">{name}</h3>
         </header>
-        
+
         <div className="px-4 pb-3" itemProp="description">
           {children}
         </div>
-        
-        <div className="mt-auto px-4 pb-2 font-semibold text-gray-600" itemScope itemType="https://schema.org/Schedule">
+
+        <div
+          className="mt-auto px-4 pb-2 font-semibold text-gray-600"
+          itemScope
+          itemType="https://schema.org/Schedule"
+        >
           <time itemProp="startTime" dateTime={`${startTime}:00`}>
             Der {kursName} findet von {startTime} Uhr
           </time>

--- a/components/local-business-structured-data/index.tsx
+++ b/components/local-business-structured-data/index.tsx
@@ -1,25 +1,25 @@
-import Script from 'next/script'
+import Script from "next/script";
 
 interface LocalBusinessStructuredDataProps {
-  name: string
-  description: string
-  url: string
-  telephone?: string
-  email?: string
+  name: string;
+  description: string;
+  url: string;
+  telephone?: string;
+  email?: string;
   address: {
-    streetAddress: string
-    addressLocality: string
-    postalCode: string
-    addressCountry: string
-  }
+    streetAddress: string;
+    addressLocality: string;
+    postalCode: string;
+    addressCountry: string;
+  };
   geo?: {
-    latitude: number
-    longitude: number
-  }
-  openingHours?: string[]
-  logo?: string
-  image?: string
-  priceRange?: string
+    latitude: number;
+    longitude: number;
+  };
+  openingHours?: string[];
+  logo?: string;
+  image?: string;
+  priceRange?: string;
 }
 
 export default function LocalBusinessStructuredData({
@@ -33,58 +33,58 @@ export default function LocalBusinessStructuredData({
   openingHours,
   logo,
   image,
-  priceRange
+  priceRange,
 }: LocalBusinessStructuredDataProps) {
   const structuredData = {
     "@context": "https://schema.org",
     "@type": "LocalBusiness",
-    "name": name,
-    "description": description,
-    "url": url,
-    "address": {
+    name: name,
+    description: description,
+    url: url,
+    address: {
       "@type": "PostalAddress",
-      "streetAddress": address.streetAddress,
-      "addressLocality": address.addressLocality,
-      "postalCode": address.postalCode,
-      "addressCountry": address.addressCountry
+      streetAddress: address.streetAddress,
+      addressLocality: address.addressLocality,
+      postalCode: address.postalCode,
+      addressCountry: address.addressCountry,
     },
-    ...(telephone && { "telephone": telephone }),
-    ...(email && { "email": email }),
+    ...(telephone && { telephone: telephone }),
+    ...(email && { email: email }),
     ...(geo && {
-      "geo": {
+      geo: {
         "@type": "GeoCoordinates",
-        "latitude": geo.latitude,
-        "longitude": geo.longitude
-      }
+        latitude: geo.latitude,
+        longitude: geo.longitude,
+      },
     }),
-    ...(openingHours && { "openingHours": openingHours }),
+    ...(openingHours && { openingHours: openingHours }),
     ...(logo && {
-      "logo": {
+      logo: {
         "@type": "ImageObject",
-        "url": logo
-      }
+        url: logo,
+      },
     }),
     ...(image && {
-      "image": {
+      image: {
         "@type": "ImageObject",
-        "url": image
-      }
+        url: image,
+      },
     }),
-    ...(priceRange && { "priceRange": priceRange }),
-    "aggregateRating": {
+    ...(priceRange && { priceRange: priceRange }),
+    aggregateRating: {
       "@type": "AggregateRating",
-      "ratingValue": "4.8",
-      "reviewCount": "27"
-    }
-  }
+      ratingValue: "4.8",
+      reviewCount: "27",
+    },
+  };
 
   return (
     <Script
       id="local-business-structured-data"
       type="application/ld+json"
       dangerouslySetInnerHTML={{
-        __html: JSON.stringify(structuredData, null, 2)
+        __html: JSON.stringify(structuredData, null, 2),
       }}
     />
-  )
+  );
 }

--- a/components/navigation/header/index.tsx
+++ b/components/navigation/header/index.tsx
@@ -75,12 +75,10 @@ export default function Header({
                   <Link
                     key={item.name}
                     href={item.href}
-                    className={`text-md font-semibold leading-8 text-white drop-shadow-lg transition-colors hover:text-blue-200 ${
-                      isActive(item.href) 
-                        ? 'border-b-2 border-white' 
-                        : ''
+                    className={`text-md leading-8 font-semibold text-white drop-shadow-lg transition-colors hover:text-blue-200 ${
+                      isActive(item.href) ? "border-b-2 border-white" : ""
                     }`}
-                    aria-current={isActive(item.href) ? 'page' : undefined}
+                    aria-current={isActive(item.href) ? "page" : undefined}
                   >
                     {item.name}
                   </Link>
@@ -88,10 +86,10 @@ export default function Header({
             )}
             <Link
               href="/anfahrt"
-              className="inline-flex items-center rounded-md bg-sky-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-sky-500 transition-colors"
+              className="inline-flex items-center rounded-md bg-sky-600 px-3 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-sky-500"
               aria-label="Kontakt aufnehmen"
             >
-              <PhoneIcon className="h-4 w-4 mr-1" aria-hidden="true" />
+              <PhoneIcon className="mr-1 h-4 w-4" aria-hidden="true" />
               Kontakt
             </Link>
           </div>
@@ -104,8 +102,14 @@ export default function Header({
           <div className="fixed inset-0 z-50 bg-black/25" />
           <DialogPanel className="fixed inset-y-0 right-0 z-50 w-full overflow-y-auto bg-white px-6 py-6 sm:max-w-sm sm:ring-1 sm:ring-gray-900/10">
             <div className="flex items-center justify-between">
-              <Link href="/" className="-m-1.5 p-1.5" onClick={() => setMobileMenuOpen(false)}>
-                <h3 className="text-lg font-semibold text-gray-900">Hundefreunde Herzogenrath e.V.</h3>
+              <Link
+                href="/"
+                className="-m-1.5 p-1.5"
+                onClick={() => setMobileMenuOpen(false)}
+              >
+                <h3 className="text-lg font-semibold text-gray-900">
+                  Hundefreunde Herzogenrath e.V.
+                </h3>
               </Link>
               <button
                 type="button"
@@ -125,25 +129,27 @@ export default function Header({
                         <Link
                           key={item.name}
                           href={item.href}
-                          className={`-mx-3 block rounded-lg px-3 py-2 text-base font-semibold leading-7 hover:bg-gray-50 transition-colors ${
-                            isActive(item.href) 
-                              ? 'text-blue-600 bg-blue-50' 
-                              : 'text-gray-900'
+                          className={`-mx-3 block rounded-lg px-3 py-2 text-base leading-7 font-semibold transition-colors hover:bg-gray-50 ${
+                            isActive(item.href)
+                              ? "bg-blue-50 text-blue-600"
+                              : "text-gray-900"
                           }`}
                           onClick={() => setMobileMenuOpen(false)}
-                          aria-current={isActive(item.href) ? 'page' : undefined}
+                          aria-current={
+                            isActive(item.href) ? "page" : undefined
+                          }
                         >
                           {item.name}
                         </Link>
                       ),
                   )}
-                  <div className="pt-4 border-t border-gray-200">
+                  <div className="border-t border-gray-200 pt-4">
                     <Link
                       href="/anfahrt"
-                      className="flex items-center justify-center rounded-lg bg-sky-600 px-4 py-3 text-base font-semibold text-white hover:bg-sky-500 transition-colors"
+                      className="flex items-center justify-center rounded-lg bg-sky-600 px-4 py-3 text-base font-semibold text-white transition-colors hover:bg-sky-500"
                       onClick={() => setMobileMenuOpen(false)}
                     >
-                      <PhoneIcon className="h-5 w-5 mr-2" aria-hidden="true" />
+                      <PhoneIcon className="mr-2 h-5 w-5" aria-hidden="true" />
                       Kontakt aufnehmen
                     </Link>
                   </div>

--- a/components/navigation/jumbotron/index.tsx
+++ b/components/navigation/jumbotron/index.tsx
@@ -30,7 +30,7 @@ export function Slide({
         {children}
       </div>
 
-      <div className="absolute left-0 top-0 -z-10 h-full w-full">
+      <div className="absolute top-0 left-0 -z-10 h-full w-full">
         {bgImage && (
           <Image
             src={bgImage}
@@ -62,7 +62,12 @@ export default function Jumbotron({
 
   return (
     <div className="relative isolate pt-16">
-      <section className="embla" data-nosnippet role="banner" aria-label="Bildkarussell">
+      <section
+        className="embla"
+        data-nosnippet
+        role="banner"
+        aria-label="Bildkarussell"
+      >
         <div className="embla__viewport h-56 lg:h-96" ref={emblaRef}>
           <div className="embla__container">
             {slides.map((slide, index) => (

--- a/components/photo-gallery/index.tsx
+++ b/components/photo-gallery/index.tsx
@@ -26,7 +26,7 @@ function renderNextImage(
   const galleryPhoto = photo as GalleryPhoto;
   const imageClasses = clsx("cursor-zoom-in opacity-0 transition-opacity");
 
-  var imageTitle = alt;
+  let imageTitle = alt;
 
   if (galleryPhoto.albumTitle) {
     imageTitle = galleryPhoto.albumTitle;

--- a/components/photo-gallery/index.tsx
+++ b/components/photo-gallery/index.tsx
@@ -1,9 +1,14 @@
 "use client";
 
-import { Photo, RenderImageContext, RenderImageProps, RowsPhotoAlbum } from "react-photo-album";
+import {
+  Photo,
+  RenderImageContext,
+  RenderImageProps,
+  RowsPhotoAlbum,
+} from "react-photo-album";
 import Image from "next/image";
 import { showLightBoxImage } from "../lightbox";
-import clsx from 'clsx';
+import clsx from "clsx";
 
 import "react-photo-album/rows.css";
 
@@ -19,20 +24,24 @@ function renderNextImage(
   { photo, width, height }: RenderImageContext,
 ) {
   const galleryPhoto = photo as GalleryPhoto;
-  const imageClasses = clsx(
-    "cursor-zoom-in opacity-0 transition-opacity",
-  );
+  const imageClasses = clsx("cursor-zoom-in opacity-0 transition-opacity");
 
   var imageTitle = alt;
 
   if (galleryPhoto.albumTitle) {
     imageTitle = galleryPhoto.albumTitle;
   } else if (title) {
-    imageTitle = title
+    imageTitle = title;
   }
 
   return (
-    <div style={{ width: "100%", position: "relative", aspectRatio: `${width} / ${height}` }}>
+    <div
+      style={{
+        width: "100%",
+        position: "relative",
+        aspectRatio: `${width} / ${height}`,
+      }}
+    >
       <Image
         src={photo}
         alt={alt}

--- a/components/team-member/index.tsx
+++ b/components/team-member/index.tsx
@@ -21,7 +21,7 @@ export interface Member {
   kurs?: Array<string>;
   dogs?: Array<Dog>;
   email?: string;
-  emailEnabled?: boolean,
+  emailEnabled?: boolean;
 }
 
 function Kurse({ kurse }: { kurse: Array<string> }) {

--- a/configuration/index.tsx
+++ b/configuration/index.tsx
@@ -1,7 +1,8 @@
 export default function PageBaseConfiguration() {
   return {
     title: "Hundefreunde Herzogenrath e.V.",
-    description: "Die Hundefreunde Herzogenrath sind die freundliche Hundeschule in der Städteregion Aachen - Besucht uns doch einmal für eine kostenlose Probestunde!",
+    description:
+      "Die Hundefreunde Herzogenrath sind die freundliche Hundeschule in der Städteregion Aachen - Besucht uns doch einmal für eine kostenlose Probestunde!",
     baseUrl: new URL("https://hundefreunde-herzogenrath.de"),
     publisher: "Patrick Arns",
     creator: "Patrick Arns",

--- a/data-provider/contentful/types/TypeBackgroundImages.ts
+++ b/data-provider/contentful/types/TypeBackgroundImages.ts
@@ -1,4 +1,10 @@
-import type { ChainModifiers, Entry, EntryFieldTypes, EntrySkeletonType, LocaleCode } from "contentful";
+import type {
+  ChainModifiers,
+  Entry,
+  EntryFieldTypes,
+  EntrySkeletonType,
+  LocaleCode,
+} from "contentful";
 
 /**
  * Fields type definition for content type 'TypeBackgroundImages'
@@ -7,24 +13,24 @@ import type { ChainModifiers, Entry, EntryFieldTypes, EntrySkeletonType, LocaleC
  * @memberof TypeBackgroundImages
  */
 export interface TypeBackgroundImagesFields {
-    /**
-     * Field type definition for field 'name' (Name)
-     * @name Name
-     * @localized false
-     */
-    name?: EntryFieldTypes.Symbol;
-    /**
-     * Field type definition for field 'position' (Position)
-     * @name Position
-     * @localized false
-     */
-    position: EntryFieldTypes.Symbol<"Bottom" | "Center" | "Top">;
-    /**
-     * Field type definition for field 'image' (Image)
-     * @name Image
-     * @localized false
-     */
-    image?: EntryFieldTypes.AssetLink;
+  /**
+   * Field type definition for field 'name' (Name)
+   * @name Name
+   * @localized false
+   */
+  name?: EntryFieldTypes.Symbol;
+  /**
+   * Field type definition for field 'position' (Position)
+   * @name Position
+   * @localized false
+   */
+  position: EntryFieldTypes.Symbol<"Bottom" | "Center" | "Top">;
+  /**
+   * Field type definition for field 'image' (Image)
+   * @name Image
+   * @localized false
+   */
+  image?: EntryFieldTypes.AssetLink;
 }
 
 /**
@@ -35,7 +41,10 @@ export interface TypeBackgroundImagesFields {
  * @since 2022-05-27T15:02:15.459Z
  * @version 11
  */
-export type TypeBackgroundImagesSkeleton = EntrySkeletonType<TypeBackgroundImagesFields, "backgroundImages">;
+export type TypeBackgroundImagesSkeleton = EntrySkeletonType<
+  TypeBackgroundImagesFields,
+  "backgroundImages"
+>;
 /**
  * Entry type definition for content type 'backgroundImages' (Background Images)
  * @name TypeBackgroundImages
@@ -45,4 +54,7 @@ export type TypeBackgroundImagesSkeleton = EntrySkeletonType<TypeBackgroundImage
  * @version 11
  * @link https://app.contentful.com/spaces/1hyew6sbxidu/environments/master/content_types/backgroundImages
  */
-export type TypeBackgroundImages<Modifiers extends ChainModifiers, Locales extends LocaleCode> = Entry<TypeBackgroundImagesSkeleton, Modifiers, Locales>;
+export type TypeBackgroundImages<
+  Modifiers extends ChainModifiers,
+  Locales extends LocaleCode,
+> = Entry<TypeBackgroundImagesSkeleton, Modifiers, Locales>;

--- a/data-provider/contentful/types/TypeBlogPost.ts
+++ b/data-provider/contentful/types/TypeBlogPost.ts
@@ -1,4 +1,10 @@
-import type { ChainModifiers, Entry, EntryFieldTypes, EntrySkeletonType, LocaleCode } from "contentful";
+import type {
+  ChainModifiers,
+  Entry,
+  EntryFieldTypes,
+  EntrySkeletonType,
+  LocaleCode,
+} from "contentful";
 
 /**
  * Fields type definition for content type 'TypeBlogPost'
@@ -7,60 +13,60 @@ import type { ChainModifiers, Entry, EntryFieldTypes, EntrySkeletonType, LocaleC
  * @memberof TypeBlogPost
  */
 export interface TypeBlogPostFields {
-    /**
-     * Field type definition for field 'title' (Title)
-     * @name Title
-     * @localized true
-     */
-    title?: EntryFieldTypes.Symbol;
-    /**
-     * Field type definition for field 'slug' (Slug)
-     * @name Slug
-     * @localized true
-     */
-    slug: EntryFieldTypes.Symbol;
-    /**
-     * Field type definition for field 'subTitle' (Sub Title)
-     * @name Sub Title
-     * @localized true
-     */
-    subTitle?: EntryFieldTypes.Symbol;
-    /**
-     * Field type definition for field 'publishedAt' (Published at)
-     * @name Published at
-     * @localized false
-     */
-    publishedAt: EntryFieldTypes.Date;
-    /**
-     * Field type definition for field 'translations' (Translations)
-     * @name Translations
-     * @localized false
-     */
-    translations?: EntryFieldTypes.Array<EntryFieldTypes.Symbol<"DE" | "EN">>;
-    /**
-     * Field type definition for field 'listEntry' (List entry)
-     * @name List entry
-     * @localized false
-     */
-    listEntry: EntryFieldTypes.Boolean;
-    /**
-     * Field type definition for field 'image' (Image)
-     * @name Image
-     * @localized false
-     */
-    image: EntryFieldTypes.AssetLink;
-    /**
-     * Field type definition for field 'body' (Body)
-     * @name Body
-     * @localized true
-     */
-    body: EntryFieldTypes.RichText;
-    /**
-     * Field type definition for field 'excerpt' (Excerpt)
-     * @name Excerpt
-     * @localized true
-     */
-    excerpt: EntryFieldTypes.Text;
+  /**
+   * Field type definition for field 'title' (Title)
+   * @name Title
+   * @localized true
+   */
+  title?: EntryFieldTypes.Symbol;
+  /**
+   * Field type definition for field 'slug' (Slug)
+   * @name Slug
+   * @localized true
+   */
+  slug: EntryFieldTypes.Symbol;
+  /**
+   * Field type definition for field 'subTitle' (Sub Title)
+   * @name Sub Title
+   * @localized true
+   */
+  subTitle?: EntryFieldTypes.Symbol;
+  /**
+   * Field type definition for field 'publishedAt' (Published at)
+   * @name Published at
+   * @localized false
+   */
+  publishedAt: EntryFieldTypes.Date;
+  /**
+   * Field type definition for field 'translations' (Translations)
+   * @name Translations
+   * @localized false
+   */
+  translations?: EntryFieldTypes.Array<EntryFieldTypes.Symbol<"DE" | "EN">>;
+  /**
+   * Field type definition for field 'listEntry' (List entry)
+   * @name List entry
+   * @localized false
+   */
+  listEntry: EntryFieldTypes.Boolean;
+  /**
+   * Field type definition for field 'image' (Image)
+   * @name Image
+   * @localized false
+   */
+  image: EntryFieldTypes.AssetLink;
+  /**
+   * Field type definition for field 'body' (Body)
+   * @name Body
+   * @localized true
+   */
+  body: EntryFieldTypes.RichText;
+  /**
+   * Field type definition for field 'excerpt' (Excerpt)
+   * @name Excerpt
+   * @localized true
+   */
+  excerpt: EntryFieldTypes.Text;
 }
 
 /**
@@ -71,7 +77,10 @@ export interface TypeBlogPostFields {
  * @since 2023-01-20T16:33:53.681Z
  * @version 37
  */
-export type TypeBlogPostSkeleton = EntrySkeletonType<TypeBlogPostFields, "blogPost">;
+export type TypeBlogPostSkeleton = EntrySkeletonType<
+  TypeBlogPostFields,
+  "blogPost"
+>;
 /**
  * Entry type definition for content type 'blogPost' (Blog Post)
  * @name TypeBlogPost
@@ -81,4 +90,7 @@ export type TypeBlogPostSkeleton = EntrySkeletonType<TypeBlogPostFields, "blogPo
  * @version 37
  * @link https://app.contentful.com/spaces/1hyew6sbxidu/environments/master/content_types/blogPost
  */
-export type TypeBlogPost<Modifiers extends ChainModifiers, Locales extends LocaleCode> = Entry<TypeBlogPostSkeleton, Modifiers, Locales>;
+export type TypeBlogPost<
+  Modifiers extends ChainModifiers,
+  Locales extends LocaleCode,
+> = Entry<TypeBlogPostSkeleton, Modifiers, Locales>;

--- a/data-provider/contentful/types/TypeBlogPostImage.ts
+++ b/data-provider/contentful/types/TypeBlogPostImage.ts
@@ -1,4 +1,10 @@
-import type { ChainModifiers, Entry, EntryFieldTypes, EntrySkeletonType, LocaleCode } from "contentful";
+import type {
+  ChainModifiers,
+  Entry,
+  EntryFieldTypes,
+  EntrySkeletonType,
+  LocaleCode,
+} from "contentful";
 
 /**
  * Fields type definition for content type 'TypeBlogPostImage'
@@ -7,66 +13,66 @@ import type { ChainModifiers, Entry, EntryFieldTypes, EntrySkeletonType, LocaleC
  * @memberof TypeBlogPostImage
  */
 export interface TypeBlogPostImageFields {
-    /**
-     * Field type definition for field 'name' (Name)
-     * @name Name
-     * @localized true
-     */
-    name?: EntryFieldTypes.Symbol;
-    /**
-     * Field type definition for field 'image' (Image)
-     * @name Image
-     * @localized false
-     */
-    image: EntryFieldTypes.AssetLink;
-    /**
-     * Field type definition for field 'showSubtitle' (Show subtitle)
-     * @name Show subtitle
-     * @localized false
-     */
-    showSubtitle?: EntryFieldTypes.Boolean;
-    /**
-     * Field type definition for field 'useDefaultStyle' (Use default Style)
-     * @name Use default Style
-     * @localized false
-     */
-    useDefaultStyle?: EntryFieldTypes.Boolean;
-    /**
-     * Field type definition for field 'useLightBox' (LightBox)
-     * @name LightBox
-     * @localized false
-     */
-    useLightBox?: EntryFieldTypes.Boolean;
-    /**
-     * Field type definition for field 'floatingDirection' (Float)
-     * @name Float
-     * @localized false
-     */
-    floatingDirection?: EntryFieldTypes.Symbol<"Left" | "None" | "Right">;
-    /**
-     * Field type definition for field 'maxWidth' (Max Width)
-     * @name Max Width
-     * @localized false
-     */
-    maxWidth: EntryFieldTypes.Integer;
-    /**
-     * Field type definition for field 'classes' (Classes)
-     * @name Classes
-     * @localized false
-     */
-    classes?: EntryFieldTypes.Array<EntryFieldTypes.Symbol>;
-    /**
-     * Field type definition for field 'imageClasses' (Image Classes)
-     * @name Image Classes
-     * @localized false
-     */
-    imageClasses?: EntryFieldTypes.Array<EntryFieldTypes.Symbol>;
-    /**
-     * Field type definition for field 'styles' (Styles)
-     * @name Styles
-     * @localized false
-     */
-    styles?: EntryFieldTypes.Object;
+  /**
+   * Field type definition for field 'name' (Name)
+   * @name Name
+   * @localized true
+   */
+  name?: EntryFieldTypes.Symbol;
+  /**
+   * Field type definition for field 'image' (Image)
+   * @name Image
+   * @localized false
+   */
+  image: EntryFieldTypes.AssetLink;
+  /**
+   * Field type definition for field 'showSubtitle' (Show subtitle)
+   * @name Show subtitle
+   * @localized false
+   */
+  showSubtitle?: EntryFieldTypes.Boolean;
+  /**
+   * Field type definition for field 'useDefaultStyle' (Use default Style)
+   * @name Use default Style
+   * @localized false
+   */
+  useDefaultStyle?: EntryFieldTypes.Boolean;
+  /**
+   * Field type definition for field 'useLightBox' (LightBox)
+   * @name LightBox
+   * @localized false
+   */
+  useLightBox?: EntryFieldTypes.Boolean;
+  /**
+   * Field type definition for field 'floatingDirection' (Float)
+   * @name Float
+   * @localized false
+   */
+  floatingDirection?: EntryFieldTypes.Symbol<"Left" | "None" | "Right">;
+  /**
+   * Field type definition for field 'maxWidth' (Max Width)
+   * @name Max Width
+   * @localized false
+   */
+  maxWidth: EntryFieldTypes.Integer;
+  /**
+   * Field type definition for field 'classes' (Classes)
+   * @name Classes
+   * @localized false
+   */
+  classes?: EntryFieldTypes.Array<EntryFieldTypes.Symbol>;
+  /**
+   * Field type definition for field 'imageClasses' (Image Classes)
+   * @name Image Classes
+   * @localized false
+   */
+  imageClasses?: EntryFieldTypes.Array<EntryFieldTypes.Symbol>;
+  /**
+   * Field type definition for field 'styles' (Styles)
+   * @name Styles
+   * @localized false
+   */
+  styles?: EntryFieldTypes.Object;
 }
 
 /**
@@ -77,7 +83,10 @@ export interface TypeBlogPostImageFields {
  * @since 2023-02-12T11:29:06.508Z
  * @version 37
  */
-export type TypeBlogPostImageSkeleton = EntrySkeletonType<TypeBlogPostImageFields, "blogPostImage">;
+export type TypeBlogPostImageSkeleton = EntrySkeletonType<
+  TypeBlogPostImageFields,
+  "blogPostImage"
+>;
 /**
  * Entry type definition for content type 'blogPostImage' (Blog Post Image)
  * @name TypeBlogPostImage
@@ -87,4 +96,7 @@ export type TypeBlogPostImageSkeleton = EntrySkeletonType<TypeBlogPostImageField
  * @version 37
  * @link https://app.contentful.com/spaces/1hyew6sbxidu/environments/master/content_types/blogPostImage
  */
-export type TypeBlogPostImage<Modifiers extends ChainModifiers, Locales extends LocaleCode> = Entry<TypeBlogPostImageSkeleton, Modifiers, Locales>;
+export type TypeBlogPostImage<
+  Modifiers extends ChainModifiers,
+  Locales extends LocaleCode,
+> = Entry<TypeBlogPostImageSkeleton, Modifiers, Locales>;

--- a/data-provider/contentful/types/TypeBlogPostVideo.ts
+++ b/data-provider/contentful/types/TypeBlogPostVideo.ts
@@ -1,4 +1,10 @@
-import type { ChainModifiers, Entry, EntryFieldTypes, EntrySkeletonType, LocaleCode } from "contentful";
+import type {
+  ChainModifiers,
+  Entry,
+  EntryFieldTypes,
+  EntrySkeletonType,
+  LocaleCode,
+} from "contentful";
 
 /**
  * Fields type definition for content type 'TypeBlogPostVideo'
@@ -7,18 +13,18 @@ import type { ChainModifiers, Entry, EntryFieldTypes, EntrySkeletonType, LocaleC
  * @memberof TypeBlogPostVideo
  */
 export interface TypeBlogPostVideoFields {
-    /**
-     * Field type definition for field 'title' (Title)
-     * @name Title
-     * @localized true
-     */
-    title: EntryFieldTypes.Symbol;
-    /**
-     * Field type definition for field 'videoUrl' (VideoUrl)
-     * @name VideoUrl
-     * @localized true
-     */
-    videoUrl: EntryFieldTypes.Symbol;
+  /**
+   * Field type definition for field 'title' (Title)
+   * @name Title
+   * @localized true
+   */
+  title: EntryFieldTypes.Symbol;
+  /**
+   * Field type definition for field 'videoUrl' (VideoUrl)
+   * @name VideoUrl
+   * @localized true
+   */
+  videoUrl: EntryFieldTypes.Symbol;
 }
 
 /**
@@ -29,7 +35,10 @@ export interface TypeBlogPostVideoFields {
  * @since 2024-04-13T09:14:50.409Z
  * @version 1
  */
-export type TypeBlogPostVideoSkeleton = EntrySkeletonType<TypeBlogPostVideoFields, "blogPostVideo">;
+export type TypeBlogPostVideoSkeleton = EntrySkeletonType<
+  TypeBlogPostVideoFields,
+  "blogPostVideo"
+>;
 /**
  * Entry type definition for content type 'blogPostVideo' (Blog Post Video)
  * @name TypeBlogPostVideo
@@ -39,4 +48,7 @@ export type TypeBlogPostVideoSkeleton = EntrySkeletonType<TypeBlogPostVideoField
  * @version 1
  * @link https://app.contentful.com/spaces/1hyew6sbxidu/environments/master/content_types/blogPostVideo
  */
-export type TypeBlogPostVideo<Modifiers extends ChainModifiers, Locales extends LocaleCode> = Entry<TypeBlogPostVideoSkeleton, Modifiers, Locales>;
+export type TypeBlogPostVideo<
+  Modifiers extends ChainModifiers,
+  Locales extends LocaleCode,
+> = Entry<TypeBlogPostVideoSkeleton, Modifiers, Locales>;

--- a/data-provider/contentful/types/TypeImageGallery.ts
+++ b/data-provider/contentful/types/TypeImageGallery.ts
@@ -1,4 +1,10 @@
-import type { ChainModifiers, Entry, EntryFieldTypes, EntrySkeletonType, LocaleCode } from "contentful";
+import type {
+  ChainModifiers,
+  Entry,
+  EntryFieldTypes,
+  EntrySkeletonType,
+  LocaleCode,
+} from "contentful";
 
 /**
  * Fields type definition for content type 'TypeImageGallery'
@@ -7,48 +13,48 @@ import type { ChainModifiers, Entry, EntryFieldTypes, EntrySkeletonType, LocaleC
  * @memberof TypeImageGallery
  */
 export interface TypeImageGalleryFields {
-    /**
-     * Field type definition for field 'name' (Name)
-     * @name Name
-     * @localized true
-     */
-    name: EntryFieldTypes.Symbol;
-    /**
-     * Field type definition for field 'slug' (Slug)
-     * @name Slug
-     * @localized true
-     */
-    slug?: EntryFieldTypes.Symbol;
-    /**
-     * Field type definition for field 'date' (Date)
-     * @name Date
-     * @localized false
-     */
-    date?: EntryFieldTypes.Date;
-    /**
-     * Field type definition for field 'description' (Description)
-     * @name Description
-     * @localized true
-     */
-    description?: EntryFieldTypes.Text;
-    /**
-     * Field type definition for field 'expandableInBlog' (Expandable in Blog)
-     * @name Expandable in Blog
-     * @localized false
-     */
-    expandableInBlog: EntryFieldTypes.Boolean;
-    /**
-     * Field type definition for field 'teaserImage' (TeaserImage)
-     * @name TeaserImage
-     * @localized false
-     */
-    teaserImage?: EntryFieldTypes.AssetLink;
-    /**
-     * Field type definition for field 'images' (Images)
-     * @name Images
-     * @localized false
-     */
-    images?: EntryFieldTypes.Array<EntryFieldTypes.AssetLink>;
+  /**
+   * Field type definition for field 'name' (Name)
+   * @name Name
+   * @localized true
+   */
+  name: EntryFieldTypes.Symbol;
+  /**
+   * Field type definition for field 'slug' (Slug)
+   * @name Slug
+   * @localized true
+   */
+  slug?: EntryFieldTypes.Symbol;
+  /**
+   * Field type definition for field 'date' (Date)
+   * @name Date
+   * @localized false
+   */
+  date?: EntryFieldTypes.Date;
+  /**
+   * Field type definition for field 'description' (Description)
+   * @name Description
+   * @localized true
+   */
+  description?: EntryFieldTypes.Text;
+  /**
+   * Field type definition for field 'expandableInBlog' (Expandable in Blog)
+   * @name Expandable in Blog
+   * @localized false
+   */
+  expandableInBlog: EntryFieldTypes.Boolean;
+  /**
+   * Field type definition for field 'teaserImage' (TeaserImage)
+   * @name TeaserImage
+   * @localized false
+   */
+  teaserImage?: EntryFieldTypes.AssetLink;
+  /**
+   * Field type definition for field 'images' (Images)
+   * @name Images
+   * @localized false
+   */
+  images?: EntryFieldTypes.Array<EntryFieldTypes.AssetLink>;
 }
 
 /**
@@ -59,7 +65,10 @@ export interface TypeImageGalleryFields {
  * @since 2023-02-10T18:33:21.266Z
  * @version 15
  */
-export type TypeImageGallerySkeleton = EntrySkeletonType<TypeImageGalleryFields, "imageGallery">;
+export type TypeImageGallerySkeleton = EntrySkeletonType<
+  TypeImageGalleryFields,
+  "imageGallery"
+>;
 /**
  * Entry type definition for content type 'imageGallery' (Image Gallery)
  * @name TypeImageGallery
@@ -69,4 +78,7 @@ export type TypeImageGallerySkeleton = EntrySkeletonType<TypeImageGalleryFields,
  * @version 15
  * @link https://app.contentful.com/spaces/1hyew6sbxidu/environments/master/content_types/imageGallery
  */
-export type TypeImageGallery<Modifiers extends ChainModifiers, Locales extends LocaleCode> = Entry<TypeImageGallerySkeleton, Modifiers, Locales>;
+export type TypeImageGallery<
+  Modifiers extends ChainModifiers,
+  Locales extends LocaleCode,
+> = Entry<TypeImageGallerySkeleton, Modifiers, Locales>;

--- a/data-provider/contentful/types/TypeProject.ts
+++ b/data-provider/contentful/types/TypeProject.ts
@@ -1,4 +1,10 @@
-import type { ChainModifiers, Entry, EntryFieldTypes, EntrySkeletonType, LocaleCode } from "contentful";
+import type {
+  ChainModifiers,
+  Entry,
+  EntryFieldTypes,
+  EntrySkeletonType,
+  LocaleCode,
+} from "contentful";
 
 /**
  * Fields type definition for content type 'TypeProject'
@@ -7,78 +13,80 @@ import type { ChainModifiers, Entry, EntryFieldTypes, EntrySkeletonType, LocaleC
  * @memberof TypeProject
  */
 export interface TypeProjectFields {
-    /**
-     * Field type definition for field 'name' (Name)
-     * @name Name
-     * @localized false
-     */
-    name?: EntryFieldTypes.Symbol;
-    /**
-     * Field type definition for field 'slogan' (Slogan)
-     * @name Slogan
-     * @localized false
-     */
-    slogan?: EntryFieldTypes.Symbol;
-    /**
-     * Field type definition for field 'slug' (Slug)
-     * @name Slug
-     * @localized false
-     */
-    slug?: EntryFieldTypes.Symbol;
-    /**
-     * Field type definition for field 'projectUrl' (ProjectUrl)
-     * @name ProjectUrl
-     * @localized false
-     */
-    projectUrl?: EntryFieldTypes.Symbol;
-    /**
-     * Field type definition for field 'headerImage' (HeaderImage)
-     * @name HeaderImage
-     * @localized false
-     */
-    headerImage?: EntryFieldTypes.AssetLink;
-    /**
-     * Field type definition for field 'icon' (Icon)
-     * @name Icon
-     * @localized false
-     */
-    icon?: EntryFieldTypes.AssetLink;
-    /**
-     * Field type definition for field 'startDate' (StartDate)
-     * @name StartDate
-     * @localized false
-     */
-    startDate?: EntryFieldTypes.Date;
-    /**
-     * Field type definition for field 'status' (Status)
-     * @name Status
-     * @localized false
-     */
-    status: EntryFieldTypes.Symbol<"Active" | "Deprecated" | "Maintenance">;
-    /**
-     * Field type definition for field 'type' (Type)
-     * @name Type
-     * @localized false
-     */
-    type?: EntryFieldTypes.Array<EntryFieldTypes.Symbol<"Kommerziell" | "Open Source" | "Privates Projekt">>;
-    /**
-     * Field type definition for field 'heroProject' (Hero Project)
-     * @name Hero Project
-     * @localized false
-     */
-    heroProject?: EntryFieldTypes.Boolean;
-    /**
-     * Field type definition for field 'shortDescription' (ShortDescription)
-     * @name ShortDescription
-     * @localized false
-     */
-    shortDescription?: EntryFieldTypes.Text;
-    /**
-     * Field type definition for field 'description' (Description)
-     * @name Description
-     * @localized false
-     */
-    description?: EntryFieldTypes.RichText;
+  /**
+   * Field type definition for field 'name' (Name)
+   * @name Name
+   * @localized false
+   */
+  name?: EntryFieldTypes.Symbol;
+  /**
+   * Field type definition for field 'slogan' (Slogan)
+   * @name Slogan
+   * @localized false
+   */
+  slogan?: EntryFieldTypes.Symbol;
+  /**
+   * Field type definition for field 'slug' (Slug)
+   * @name Slug
+   * @localized false
+   */
+  slug?: EntryFieldTypes.Symbol;
+  /**
+   * Field type definition for field 'projectUrl' (ProjectUrl)
+   * @name ProjectUrl
+   * @localized false
+   */
+  projectUrl?: EntryFieldTypes.Symbol;
+  /**
+   * Field type definition for field 'headerImage' (HeaderImage)
+   * @name HeaderImage
+   * @localized false
+   */
+  headerImage?: EntryFieldTypes.AssetLink;
+  /**
+   * Field type definition for field 'icon' (Icon)
+   * @name Icon
+   * @localized false
+   */
+  icon?: EntryFieldTypes.AssetLink;
+  /**
+   * Field type definition for field 'startDate' (StartDate)
+   * @name StartDate
+   * @localized false
+   */
+  startDate?: EntryFieldTypes.Date;
+  /**
+   * Field type definition for field 'status' (Status)
+   * @name Status
+   * @localized false
+   */
+  status: EntryFieldTypes.Symbol<"Active" | "Deprecated" | "Maintenance">;
+  /**
+   * Field type definition for field 'type' (Type)
+   * @name Type
+   * @localized false
+   */
+  type?: EntryFieldTypes.Array<
+    EntryFieldTypes.Symbol<"Kommerziell" | "Open Source" | "Privates Projekt">
+  >;
+  /**
+   * Field type definition for field 'heroProject' (Hero Project)
+   * @name Hero Project
+   * @localized false
+   */
+  heroProject?: EntryFieldTypes.Boolean;
+  /**
+   * Field type definition for field 'shortDescription' (ShortDescription)
+   * @name ShortDescription
+   * @localized false
+   */
+  shortDescription?: EntryFieldTypes.Text;
+  /**
+   * Field type definition for field 'description' (Description)
+   * @name Description
+   * @localized false
+   */
+  description?: EntryFieldTypes.RichText;
 }
 
 /**
@@ -89,7 +97,10 @@ export interface TypeProjectFields {
  * @since 2023-02-24T16:03:15.813Z
  * @version 25
  */
-export type TypeProjectSkeleton = EntrySkeletonType<TypeProjectFields, "project">;
+export type TypeProjectSkeleton = EntrySkeletonType<
+  TypeProjectFields,
+  "project"
+>;
 /**
  * Entry type definition for content type 'project' (Project)
  * @name TypeProject
@@ -99,4 +110,7 @@ export type TypeProjectSkeleton = EntrySkeletonType<TypeProjectFields, "project"
  * @version 25
  * @link https://app.contentful.com/spaces/1hyew6sbxidu/environments/master/content_types/project
  */
-export type TypeProject<Modifiers extends ChainModifiers, Locales extends LocaleCode> = Entry<TypeProjectSkeleton, Modifiers, Locales>;
+export type TypeProject<
+  Modifiers extends ChainModifiers,
+  Locales extends LocaleCode,
+> = Entry<TypeProjectSkeleton, Modifiers, Locales>;

--- a/data-provider/contentful/types/TypeSocialMediaLink.ts
+++ b/data-provider/contentful/types/TypeSocialMediaLink.ts
@@ -1,4 +1,10 @@
-import type { ChainModifiers, Entry, EntryFieldTypes, EntrySkeletonType, LocaleCode } from "contentful";
+import type {
+  ChainModifiers,
+  Entry,
+  EntryFieldTypes,
+  EntrySkeletonType,
+  LocaleCode,
+} from "contentful";
 
 /**
  * Fields type definition for content type 'TypeSocialMediaLink'
@@ -7,36 +13,36 @@ import type { ChainModifiers, Entry, EntryFieldTypes, EntrySkeletonType, LocaleC
  * @memberof TypeSocialMediaLink
  */
 export interface TypeSocialMediaLinkFields {
-    /**
-     * Field type definition for field 'name' (Name)
-     * @name Name
-     * @localized false
-     */
-    name?: EntryFieldTypes.Symbol;
-    /**
-     * Field type definition for field 'title' (Title)
-     * @name Title
-     * @localized false
-     */
-    title?: EntryFieldTypes.Symbol;
-    /**
-     * Field type definition for field 'icon' (Icon)
-     * @name Icon
-     * @localized false
-     */
-    icon?: EntryFieldTypes.AssetLink;
-    /**
-     * Field type definition for field 'link' (Link)
-     * @name Link
-     * @localized false
-     */
-    link?: EntryFieldTypes.Symbol;
-    /**
-     * Field type definition for field 'order' (Order)
-     * @name Order
-     * @localized false
-     */
-    order?: EntryFieldTypes.Integer;
+  /**
+   * Field type definition for field 'name' (Name)
+   * @name Name
+   * @localized false
+   */
+  name?: EntryFieldTypes.Symbol;
+  /**
+   * Field type definition for field 'title' (Title)
+   * @name Title
+   * @localized false
+   */
+  title?: EntryFieldTypes.Symbol;
+  /**
+   * Field type definition for field 'icon' (Icon)
+   * @name Icon
+   * @localized false
+   */
+  icon?: EntryFieldTypes.AssetLink;
+  /**
+   * Field type definition for field 'link' (Link)
+   * @name Link
+   * @localized false
+   */
+  link?: EntryFieldTypes.Symbol;
+  /**
+   * Field type definition for field 'order' (Order)
+   * @name Order
+   * @localized false
+   */
+  order?: EntryFieldTypes.Integer;
 }
 
 /**
@@ -47,7 +53,10 @@ export interface TypeSocialMediaLinkFields {
  * @since 2023-02-10T16:43:08.742Z
  * @version 9
  */
-export type TypeSocialMediaLinkSkeleton = EntrySkeletonType<TypeSocialMediaLinkFields, "socialMediaLink">;
+export type TypeSocialMediaLinkSkeleton = EntrySkeletonType<
+  TypeSocialMediaLinkFields,
+  "socialMediaLink"
+>;
 /**
  * Entry type definition for content type 'socialMediaLink' (Social Media Link)
  * @name TypeSocialMediaLink
@@ -57,4 +66,7 @@ export type TypeSocialMediaLinkSkeleton = EntrySkeletonType<TypeSocialMediaLinkF
  * @version 9
  * @link https://app.contentful.com/spaces/1hyew6sbxidu/environments/master/content_types/socialMediaLink
  */
-export type TypeSocialMediaLink<Modifiers extends ChainModifiers, Locales extends LocaleCode> = Entry<TypeSocialMediaLinkSkeleton, Modifiers, Locales>;
+export type TypeSocialMediaLink<
+  Modifiers extends ChainModifiers,
+  Locales extends LocaleCode,
+> = Entry<TypeSocialMediaLinkSkeleton, Modifiers, Locales>;

--- a/data-provider/contentful/types/index.ts
+++ b/data-provider/contentful/types/index.ts
@@ -1,7 +1,35 @@
-export type { TypeBackgroundImages, TypeBackgroundImagesFields, TypeBackgroundImagesSkeleton } from "./TypeBackgroundImages";
-export type { TypeBlogPost, TypeBlogPostFields, TypeBlogPostSkeleton } from "./TypeBlogPost";
-export type { TypeBlogPostImage, TypeBlogPostImageFields, TypeBlogPostImageSkeleton } from "./TypeBlogPostImage";
-export type { TypeBlogPostVideo, TypeBlogPostVideoFields, TypeBlogPostVideoSkeleton } from "./TypeBlogPostVideo";
-export type { TypeImageGallery, TypeImageGalleryFields, TypeImageGallerySkeleton } from "./TypeImageGallery";
-export type { TypeProject, TypeProjectFields, TypeProjectSkeleton } from "./TypeProject";
-export type { TypeSocialMediaLink, TypeSocialMediaLinkFields, TypeSocialMediaLinkSkeleton } from "./TypeSocialMediaLink";
+export type {
+  TypeBackgroundImages,
+  TypeBackgroundImagesFields,
+  TypeBackgroundImagesSkeleton,
+} from "./TypeBackgroundImages";
+export type {
+  TypeBlogPost,
+  TypeBlogPostFields,
+  TypeBlogPostSkeleton,
+} from "./TypeBlogPost";
+export type {
+  TypeBlogPostImage,
+  TypeBlogPostImageFields,
+  TypeBlogPostImageSkeleton,
+} from "./TypeBlogPostImage";
+export type {
+  TypeBlogPostVideo,
+  TypeBlogPostVideoFields,
+  TypeBlogPostVideoSkeleton,
+} from "./TypeBlogPostVideo";
+export type {
+  TypeImageGallery,
+  TypeImageGalleryFields,
+  TypeImageGallerySkeleton,
+} from "./TypeImageGallery";
+export type {
+  TypeProject,
+  TypeProjectFields,
+  TypeProjectSkeleton,
+} from "./TypeProject";
+export type {
+  TypeSocialMediaLink,
+  TypeSocialMediaLinkFields,
+  TypeSocialMediaLinkSkeleton,
+} from "./TypeSocialMediaLink";

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,23 +6,23 @@ const nextConfig = {
       { hostname: "downloads.ctfassets.net" },
     ],
     minimumCacheTTL: 2592000,
-    formats: ['image/webp', 'image/avif'],
+    formats: ["image/webp", "image/avif"],
     deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
   },
   // Performance Optimizations
   experimental: {
     optimizePackageImports: [
-      '@heroicons/react', 
-      '@headlessui/react',
-      '@contentful/rich-text-react-renderer',
-      '@contentful/rich-text-types',
-      'react-photo-album',
-      'embla-carousel-react',
-      'embla-carousel-autoplay',
-      'clsx'
+      "@heroicons/react",
+      "@headlessui/react",
+      "@contentful/rich-text-react-renderer",
+      "@contentful/rich-text-types",
+      "react-photo-album",
+      "embla-carousel-react",
+      "embla-carousel-autoplay",
+      "clsx",
     ],
-  }
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.3",
     "@tailwindcss/typography": "^0.5.20",
-    "@types/node": "^25.6.0",
+    "@types/node": "^26.1.1",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "eslint": "^9.39.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,8 +92,8 @@ importers:
         specifier: ^0.5.20
         version: 0.5.20(tailwindcss@4.3.3)
       '@types/node':
-        specifier: ^25.6.0
-        version: 25.6.0
+        specifier: ^26.1.1
+        version: 26.1.1
       '@types/react':
         specifier: 19.2.17
         version: 19.2.17
@@ -768,8 +768,8 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
-  '@types/node@25.6.0':
-    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+  '@types/node@26.1.1':
+    resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -2366,8 +2366,8 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
-  undici-types@7.19.2:
-    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
@@ -3001,9 +3001,9 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
-  '@types/node@25.6.0':
+  '@types/node@26.1.1':
     dependencies:
-      undici-types: 7.19.2
+      undici-types: 8.3.0
 
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
@@ -4772,7 +4772,7 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  undici-types@7.19.2: {}
+  undici-types@8.3.0: {}
 
   unrs-resolver@1.11.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
 onlyBuiltDependencies:
-  - '@tailwindcss/oxide'
+  - "@tailwindcss/oxide"
   - sharp
   - unrs-resolver

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,7 +1,7 @@
 /** @type {import('postcss-load-config').Config} */
 const config = {
   plugins: {
-    '@tailwindcss/postcss': {},
+    "@tailwindcss/postcss": {},
   },
 };
 

--- a/prebuild.js
+++ b/prebuild.js
@@ -1,20 +1,20 @@
-import fs from 'fs';
-import path from 'path';
-import https from 'https';
+import fs from "fs";
+import path from "path";
+import https from "https";
 
-const owner = 'PArns';
-const repo = 'next.hundefreunde-herzogenrath.de';
+const owner = "PArns";
+const repo = "next.hundefreunde-herzogenrath.de";
 
 function getCommitCountFromGitHub(owner, repo) {
   return new Promise((resolve, reject) => {
     const options = {
-      hostname: 'api.github.com',
+      hostname: "api.github.com",
       path: `/repos/${owner}/${repo}/commits?per_page=1`,
-      method: 'GET',
+      method: "GET",
       headers: {
-        'User-Agent': 'BuildInfoScript',
-        'Accept': 'application/vnd.github+json'
-      }
+        "User-Agent": "BuildInfoScript",
+        Accept: "application/vnd.github+json",
+      },
     };
 
     const req = https.get(options, (res) => {
@@ -34,8 +34,8 @@ function getCommitCountFromGitHub(owner, repo) {
       resolve(count);
     });
 
-    req.on('error', (err) => {
-      console.error('Fehler beim Abrufen von Commits:', err);
+    req.on("error", (err) => {
+      console.error("Fehler beim Abrufen von Commits:", err);
       reject(err);
     });
   });
@@ -45,8 +45,8 @@ async function generateBuildInfo() {
   try {
     const commitCount = await getCommitCountFromGitHub(owner, repo);
 
-    const packageJsonPath = path.resolve(process.cwd(), 'package.json');
-    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    const packageJsonPath = path.resolve(process.cwd(), "package.json");
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
     const version = packageJson.version;
 
     const buildDate = new Date().toISOString();
@@ -55,11 +55,13 @@ async function generateBuildInfo() {
       version,
       commitCount,
       buildDate,
-      buildNumber: `${version}.${commitCount}`
+      buildNumber: `${version}.${commitCount}`,
     };
 
-    fs.writeFileSync('build-info.json', JSON.stringify(buildInfo, null, 2));
-    console.log(`✅ Build info generated: ${JSON.stringify(buildInfo, null, 2)}`);
+    fs.writeFileSync("build-info.json", JSON.stringify(buildInfo, null, 2));
+    console.log(
+      `✅ Build info generated: ${JSON.stringify(buildInfo, null, 2)}`,
+    );
   } catch (err) {
     process.exit(1);
   }

--- a/sections/faq/index.tsx
+++ b/sections/faq/index.tsx
@@ -2,41 +2,47 @@ import ContentBox from "@/components/layout/default-box";
 
 const faqs = [
   {
-    question: "Wie viel kostet eine Probestunde bei den Hundefreunden Herzogenrath?",
-    answer: "Die Probestunde ist völlig kostenlos und unverbindlich. Kommt einfach samstags zu den Trainingszeiten vorbei und meldet euch bei einem Trainer."
+    question:
+      "Wie viel kostet eine Probestunde bei den Hundefreunden Herzogenrath?",
+    answer:
+      "Die Probestunde ist völlig kostenlos und unverbindlich. Kommt einfach samstags zu den Trainingszeiten vorbei und meldet euch bei einem Trainer.",
   },
   {
     question: "Wann finden die Trainingsstunden statt?",
-    answer: "Das Training findet ausschließlich samstags statt. Die genauen Zeiten variieren je nach Kurs - Welpen ab 13:00 Uhr, Anfänger ab 14:00 Uhr, BGVP ab 15:15 Uhr und Leistung ab 16:45 Uhr."
+    answer:
+      "Das Training findet ausschließlich samstags statt. Die genauen Zeiten variieren je nach Kurs - Welpen ab 13:00 Uhr, Anfänger ab 14:00 Uhr, BGVP ab 15:15 Uhr und Leistung ab 16:45 Uhr.",
   },
   {
     question: "Kann ich jederzeit mit meinem Hund einsteigen?",
-    answer: "Bei den Welpen- und Anfängergruppen ist ein Einstieg jederzeit möglich. Für die weiterführenden Kurse (BGVP, Leistung) ist der erfolgreiche Abschluss des jeweiligen Vorkurses erforderlich."
+    answer:
+      "Bei den Welpen- und Anfängergruppen ist ein Einstieg jederzeit möglich. Für die weiterführenden Kurse (BGVP, Leistung) ist der erfolgreiche Abschluss des jeweiligen Vorkurses erforderlich.",
   },
   {
     question: "Wie lange dauern die Kurse?",
-    answer: "Unsere Kurse sind auf eine Dauer von 6 Monaten ausgelegt und starten regulär im April und Oktober. Jede Übungsstunde dauert 60 Minuten."
+    answer:
+      "Unsere Kurse sind auf eine Dauer von 6 Monaten ausgelegt und starten regulär im April und Oktober. Jede Übungsstunde dauert 60 Minuten.",
   },
   {
     question: "Bietet ihr auch Einzelunterricht an?",
-    answer: "Nein, als Verein mit ehrenamtlichen Trainern bieten wir ausschließlich Gruppentraining an. Dies fördert auch die Sozialisierung der Hunde."
-  }
+    answer:
+      "Nein, als Verein mit ehrenamtlichen Trainern bieten wir ausschließlich Gruppentraining an. Dies fördert auch die Sozialisierung der Hunde.",
+  },
 ];
 
 export default function FAQ() {
   return (
     <ContentBox>
-        <h2>Häufig gestellte Fragen</h2>
-        <div className="space-y-4">
-          {faqs.map((faq, index) => (
-            <details key={index} className="border-b pb-4">
-              <summary className="font-semibold text-sky-900 cursor-pointer hover:text-sky-700">
-                {faq.question}
-              </summary>
-              <p className="mt-2 text-gray-700">{faq.answer}</p>
-            </details>
-          ))}
-        </div>
-      </ContentBox>
+      <h2>Häufig gestellte Fragen</h2>
+      <div className="space-y-4">
+        {faqs.map((faq, index) => (
+          <details key={index} className="border-b pb-4">
+            <summary className="cursor-pointer font-semibold text-sky-900 hover:text-sky-700">
+              {faq.question}
+            </summary>
+            <p className="mt-2 text-gray-700">{faq.answer}</p>
+          </details>
+        ))}
+      </div>
+    </ContentBox>
   );
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "compilerOptions": {
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -22,9 +18,7 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./*"
-      ]
+      "@/*": ["./*"]
     },
     "target": "ES2017"
   },
@@ -36,7 +30,5 @@
     "prebuild.js",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Weekly maintenance review

Automated weekly maintenance for `next.hundefreunde-herzogenrath.de`. Lint, Prettier and the TypeScript build phase all pass. (`pnpm build` can only fail past typecheck at Contentful data-collection because no CMS credentials are available in the maintenance environment — purely environmental, not a code issue.)

### Dependencies
- **`@types/node`** bumped `^25.6.0 → ^26.1.1` (types-only major; TypeScript build phase verified green).
- Everything else is **already at the latest patch within its current major** (prior run #259): `next` 16.2.10 (latest 16.x, includes security fixes), `react`/`react-dom` 19.2.7, `postcss` 8.5.20, `prettier-plugin-tailwindcss` 0.8.1, `@tailwindcss/postcss` 4.3.3, `@types/react` 19.2.17 — so all open Dependabot targets are satisfied.
- **`eslint` held back at `^9.39.5`** (Dependabot #255 wants 10.4.0). eslint 10 crashes `pnpm lint`: `eslint-config-next@16.2.10` bundles `eslint-plugin-react@7.37.5`, which only supports eslint `^9.7` and throws `getFilename is not a function` on v10. This is the same reason the prior run restored ESLint to v9. Blocked upstream until `eslint-config-next` ships an eslint-10-compatible plugin set.
- Held back majors (out of scope / risky): `@fullcalendar/*` 6→7 (core calendar feature), `typescript` 6→7 (native compiler port).

### Security
- `pnpm audit`: **no known vulnerabilities**. Existing `pnpm.overrides` (axios, form-data, qs, brace-expansion, @babel/core, postcss) remain in place. `next` is on the latest patched 16.x.

### SEO
- **Canonical fix (significant):** the root layout set `alternates.canonical` to the site base URL, so *every subpage* emitted a canonical pointing at the homepage — a duplicate-content signal that can de-index subpages. Removed the global canonical; the homepage now carries a self-referencing canonical (`/`) and all other routes self-canonicalize by default.
- **Sitemap pagination fix:** page count hardcoded `postsPerPage = 10` while the app paginates at `blogPostsPerPage` (6), under-generating `/aktuelles/seite/N` URLs. Now derives the page size from the shared config.
- Flag for a human (not changed — business data): `LocalBusinessStructuredData` hardcodes an `aggregateRating` (4.8 / 27) with no on-page reviews, which can trip Google's structured-data review policy.

### Perf / cleanup
- Replaced `var` with `let` in the two pagination loops. No other clean for-loop wins found (the codebase already favours `.map`/`for…of`).

### Formatting
- Ran Prettier (with `prettier-plugin-tailwindcss`) across the tree to fix accumulated drift (quotes, Tailwind class ordering, wrapping). Added a `.prettierignore` so lock/generated files aren't rewritten.

### Tests
- No test runner is configured (no `test` script, no vitest/jest/playwright). None to run.

### Dependabot reconciliation
| PR | Target | Action |
|----|--------|--------|
| #253 prettier-plugin-tailwindcss 0.8.0 | ≤ 0.8.1 (current) | superseded — close |
| #254 postcss 8.5.14 | ≤ 8.5.20 (current) | superseded — close |
| #255 eslint 10.4.0 | incompatible with eslint-config-next 16 | **left open** |
| #256 @tailwindcss/postcss 4.3.0 | ≤ 4.3.3 (current) | superseded — close |
| #257 react 19.2.6 / @types/react 19.2.14 | ≤ 19.2.7 / 19.2.17 (current) | superseded — close |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017N1ZFSpXMgZEmiuWbATKo1)_